### PR TITLE
Run clang-format over our code.

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -2,9 +2,7 @@
 
 chrome.app.runtime.onLaunched.addListener(function() {
   chrome.app.window.create(
-      "app.html", {
-        outerBounds: { width: 1024, height: 768 }
-      });
+      'app.html', {outerBounds: {width: 1024, height: 768}});
 });
 
 // Use a "lite" version of the OnlyKey code to send OKSETTIME messages whenever
@@ -13,93 +11,92 @@ chrome.app.runtime.onLaunched.addListener(function() {
 //
 // Do not run this when using nwjs.
 if (typeof nw == 'undefined') {
-    var onlyKeyLite = new OnlyKeyLite();
+  var onlyKeyLite = new OnlyKeyLite();
 
-    chrome.hid.getDevices(onlyKeyLite.deviceInfo, onDevicesEnumerated);
-    chrome.hid.onDeviceAdded.addListener(onDeviceAdded);
+  chrome.hid.getDevices(onlyKeyLite.deviceInfo, onDevicesEnumerated);
+  chrome.hid.onDeviceAdded.addListener(onDeviceAdded);
 }
 
 function OnlyKeyLite() {
-    this.deviceInfo = {
-        vendorId: 5824,
-        productId: 1158
-    };
-    this.maxInputReportSize = 64;
-    this.maxOutputReportSize = 64;
-    this.maxFeatureReportSize = 0;
-    this.messageHeader = [255, 255, 255, 255];
+  this.deviceInfo = {vendorId: 5824, productId: 1158};
+  this.maxInputReportSize = 64;
+  this.maxOutputReportSize = 64;
+  this.maxFeatureReportSize = 0;
+  this.messageHeader = [255, 255, 255, 255];
 }
 
 function onDevicesEnumerated(devices) {
-    if (chrome.runtime.lastError) {
-        console.error("onDevicesEnumerated ERROR:", chrome.runtime.lastError);
-        return;
-    }
+  if (chrome.runtime.lastError) {
+    console.error('onDevicesEnumerated ERROR:', chrome.runtime.lastError);
+    return;
+  }
 
-    console.info("HID devices:", devices);
+  console.info('HID devices:', devices);
 
-    for (var device of devices) {
-        onDeviceAdded(device);
-    }
+  for (var device of devices) {
+    onDeviceAdded(device);
+  }
 }
 
 function onDeviceAdded(device) {
-    if (device.maxInputReportSize === onlyKeyLite.maxInputReportSize &&
-        device.maxOutputReportSize === onlyKeyLite.maxOutputReportSize &&
-        device.maxFeatureReportSize === onlyKeyLite.maxFeatureReportSize) {
+  if (device.maxInputReportSize === onlyKeyLite.maxInputReportSize &&
+      device.maxOutputReportSize === onlyKeyLite.maxOutputReportSize &&
+      device.maxFeatureReportSize === onlyKeyLite.maxFeatureReportSize) {
+    chrome.hid.connect(device.deviceId, function(connectInfo) {
+      if (chrome.runtime.lastError) {
+        console.error('ERROR CONNECTING:', chrome.runtime.lastError);
+      } else if (!connectInfo) {
+        console.warn('Unable to connect to device.');
+      } else {
+        console.info('CONNECTINFO:', connectInfo);
+      }
 
-        chrome.hid.connect(device.deviceId, function (connectInfo) {
-            if (chrome.runtime.lastError) {
-                console.error("ERROR CONNECTING:", chrome.runtime.lastError);
-            } else if (!connectInfo) {
-                console.warn("Unable to connect to device.");
-            } else {
-                console.info("CONNECTINFO:", connectInfo);
-            }
-
-            setTime(connectInfo.connectionId);
-        });
-    }
+      setTime(connectInfo.connectionId);
+    });
+  }
 }
 
 function setTime(connectionId) {
-    var currentEpochTime = Math.round(new Date().getTime() / 1000.0).toString(16);
-    console.info("Setting current epoch time =", currentEpochTime);
-    var timeParts = currentEpochTime.match(/.{2}/g);
-    var bytesPerMessage = 64;
-    var reportId = 0;
-    var bytes = new Uint8Array(bytesPerMessage);
-    var cursor = 0;
-    var messageHeader = [255, 255, 255, 255];
+  var currentEpochTime = Math.round(new Date().getTime() / 1000.0).toString(16);
+  console.info('Setting current epoch time =', currentEpochTime);
+  var timeParts = currentEpochTime.match(/.{2}/g);
+  var bytesPerMessage = 64;
+  var reportId = 0;
+  var bytes = new Uint8Array(bytesPerMessage);
+  var cursor = 0;
+  var messageHeader = [255, 255, 255, 255];
 
-    for (; cursor < messageHeader.length; cursor++) {
-        bytes[cursor] = messageHeader[cursor];
+  for (; cursor < messageHeader.length; cursor++) {
+    bytes[cursor] = messageHeader[cursor];
+  }
+
+  bytes[cursor] = 228;
+  cursor++;
+
+  timeParts.forEach(function(val) {
+    bytes[cursor++] = hexStrToDec(val);
+  });
+
+  var pad = 0;
+  for (; cursor < bytes.length;) {
+    bytes[cursor++] = pad;
+  }
+
+  console.info(
+      'SENDING OKSETTIME to connectionId ' + connectionId + ':', bytes);
+
+  chrome.hid.send(connectionId, reportId, bytes.buffer, function() {
+    if (chrome.runtime.lastError) {
+      console.error(
+          'ERROR SENDING OKSETTIME:', chrome.runtime.lastError,
+          {connectionId: connectionId});
+      callback('ERROR SENDING OKSETTIME PACKETS');
+    } else {
+      console.info('OKSETTIME complete');
     }
-
-    bytes[cursor] = 228;
-    cursor++;
-
-    timeParts.forEach(function (val) {
-        bytes[cursor++] = hexStrToDec(val);
-    });
-
-    var pad = 0;
-    for (;cursor < bytes.length;) {
-        bytes[cursor++] = pad;
-    }
-
-    console.info("SENDING OKSETTIME to connectionId " + connectionId + ":", bytes);
-
-    chrome.hid.send(connectionId, reportId, bytes.buffer, function () {
-        if (chrome.runtime.lastError) {
-            console.error("ERROR SENDING OKSETTIME:", chrome.runtime.lastError, { connectionId: connectionId });
-            callback('ERROR SENDING OKSETTIME PACKETS');
-        } else {
-            console.info("OKSETTIME complete");
-        }
-    });
+  });
 }
 
 function hexStrToDec(hexStr) {
-    return parseInt(hexStr, 16).toString(10);
+  return parseInt(hexStr, 16).toString(10);
 }

--- a/app/scripts/onlyKey/OnlyKeyComm.js
+++ b/app/scripts/onlyKey/OnlyKeyComm.js
@@ -4,1351 +4,1367 @@
 // accessible for integration tests. We use this to simulate an OnlyKey being
 // plugged into the computer.
 var chromeHid = {
-    // chrome.hid.connect(integer deviceId, function callback)
-    connect: function(deviceId, callback) {
-        if (deviceId === 'mockDevice') {
-            return callback({connectionId: 'mockConnection'});
-        } else {
-            return chrome.hid.connect(deviceId, callback);
-        }
+  // chrome.hid.connect(integer deviceId, function callback)
+  connect: function(deviceId, callback) {
+    if (deviceId === 'mockDevice') {
+      return callback({connectionId: 'mockConnection'});
+    } else {
+      return chrome.hid.connect(deviceId, callback);
+    }
+  },
+
+  // chrome.hid.disconnect(integer connectionId, function callback)
+  disconnect: chrome.hid.disconnect,
+
+  // chrome.hid.getDevices(object options, function callback)
+  getDevices: chrome.hid.getDevices,
+
+  // chrome.hid.receive(integer connectionId, function callback)
+  receive: function(connectionId, callback) {
+    console.log('>>> receive called with', arguments);
+    if (connectionId === 'mockConnection') {
+      if (this._pendingReceive) {
+        throw 'There must not be multiple pending receives.';
+      }
+      this._pendingReceive = callback;
+    } else {
+      return chrome.hid.receive(connectionId, callback);
+    }
+  },
+
+  mockResponse: function(response) {
+    // Response is [reportId, data]. Note that WebDriver.executeScript will
+    // convert the ArrayBuffer data to an object, so we have to convert it
+    // back.
+    var [reportId, data] = response;
+    response = [reportId, new Uint8Array(Object.values(data)).buffer];
+
+    if (!this._pendingReceive) {
+      throw 'Expected a pending receive, found none.';
+    }
+    var callback = this._pendingReceive;
+    this._pendingReceive = null;
+    callback.apply(chrome.hid, response);
+  },
+
+  _pendingReceive: null,
+
+  // chrome.hid.send(integer connectionId, integer reportId, ArrayBuffer data,
+  // function callback)
+  send: function(connectionId, reportId, data, callback) {
+    console.log('>>> send called with', arguments);
+    if (connectionId === 'mockConnection') {
+      this._sent.push(arguments);
+
+      // Simulate a successful send operation by calling the callback
+      // without setting chrome.runtime.lastError.
+      callback();
+    } else {
+      chrome.hid.send(connectionId, reportId, data, callback);
+    }
+  },
+
+  _sent: [],
+
+  // Event: chrome.hid.onDeviceAdded
+  onDeviceAdded: {
+    addListener: function(callback) {
+      this._callbacks.push(callback);
+      return chrome.hid.onDeviceAdded.addListener(callback);
     },
 
-    // chrome.hid.disconnect(integer connectionId, function callback)
-    disconnect: chrome.hid.disconnect,
+    _callbacks: [],
 
-    // chrome.hid.getDevices(object options, function callback)
-    getDevices: chrome.hid.getDevices,
-
-    // chrome.hid.receive(integer connectionId, function callback)
-    receive: function(connectionId, callback) {
-        console.log('>>> receive called with', arguments);
-        if (connectionId === 'mockConnection') {
-            if (this._pendingReceive) {
-                throw "There must not be multiple pending receives.";
-            }
-            this._pendingReceive = callback;
-        } else {
-            return chrome.hid.receive(connectionId, callback);
-        }
+    mockDeviceAdded: function() {
+      this._callbacks.forEach(function(callback) {
+        callback.call(null, {
+          'collections': [{'reportIds': [], 'usage': 1, 'usagePage': 61904}],
+          'deviceId': 'mockDevice',
+          'maxFeatureReportSize': 0,
+          'maxInputReportSize': 64,
+          'maxOutputReportSize': 64,
+          'productId': 1158,
+          'productName': 'Keyboard/RawHID',
+          'reportDescriptor': {},
+          'serialNumber': '4294967295',
+          'vendorId': 5824
+        });
+      });
     },
+  },
 
-    mockResponse: function(response) {
-        // Response is [reportId, data]. Note that WebDriver.executeScript will
-        // convert the ArrayBuffer data to an object, so we have to convert it
-        // back.
-        var [reportId, data] = response;
-        response = [reportId, new Uint8Array(Object.values(data)).buffer];
-
-        if (!this._pendingReceive) {
-            throw "Expected a pending receive, found none.";
-        }
-        var callback = this._pendingReceive;
-        this._pendingReceive = null;
-        callback.apply(chrome.hid, response);
+  // Event: chrome.hid.onDeviceRemoved
+  onDeviceRemoved: {
+    addListener: function(callback) {
+      return chrome.hid.onDeviceRemoved.addListener(callback);
     },
-
-    _pendingReceive: null,
-
-    // chrome.hid.send(integer connectionId, integer reportId, ArrayBuffer data, function callback)
-    send: function(connectionId, reportId, data, callback) {
-        console.log('>>> send called with', arguments);
-        if (connectionId === 'mockConnection') {
-            this._sent.push(arguments);
-
-            // Simulate a successful send operation by calling the callback
-            // without setting chrome.runtime.lastError.
-            callback();
-        } else {
-            chrome.hid.send(connectionId, reportId, data, callback);
-        }
-    },
-
-    _sent: [],
-
-    // Event: chrome.hid.onDeviceAdded
-    onDeviceAdded: {
-        addListener: function(callback) {
-            this._callbacks.push(callback);
-            return chrome.hid.onDeviceAdded.addListener(callback);
-        },
-
-        _callbacks: [],
-
-        mockDeviceAdded: function() {
-            this._callbacks.forEach(function(callback) {
-                callback.call(null, {
-                    "collections": [
-                        {
-                            "reportIds": [],
-                            "usage": 1,
-                            "usagePage": 61904
-                        }
-                    ],
-                    "deviceId": "mockDevice",
-                    "maxFeatureReportSize": 0,
-                    "maxInputReportSize": 64,
-                    "maxOutputReportSize": 64,
-                    "productId": 1158,
-                    "productName": "Keyboard/RawHID",
-                    "reportDescriptor": {},
-                    "serialNumber": "4294967295",
-                    "vendorId": 5824
-                });
-            });
-        },
-    },
-
-    // Event: chrome.hid.onDeviceRemoved
-    onDeviceRemoved: {
-        addListener: function(callback) {
-            return chrome.hid.onDeviceRemoved.addListener(callback);
-        },
-    },
+  },
 
 };
 
-var OnlyKeyHID = function (onlyKeyConfigWizard) {
-    var myOnlyKey = new OnlyKey();
-    var dialog = new dialogMgr();
+var OnlyKeyHID = function(onlyKeyConfigWizard) {
+  var myOnlyKey = new OnlyKey();
+  var dialog = new dialogMgr();
 
-    function OnlyKey() {
-        this.deviceInfo = {
-            vendorId: 5824,
-            productId: 1158
-        };
-        this.maxInputReportSize = 64;
-        this.maxOutputReportSize = 64;
-        this.maxFeatureReportSize = 0;
-        this.messageHeader = [255, 255, 255, 255];
-        this.messages = {
-            OKSETPIN: 225, //0xE1
-            OKSETSDPIN: 226, //0xE2
-            OKSETPDPIN: 227, //0xE3
-            OKSETTIME: 228, //0xE4
-            OKGETLABELS: 229, //0xE5
-            OKSETSLOT: 230, //0xE6
-            OKWIPESLOT: 231, //0xE7
-            OKSETU2FPRIV: 232, //0xE8
-            OKWIPEU2FPRIV: 233, //0xE9
-            OKSETU2FCERT: 234, //0xEA
-            OKWIPEU2FCERT: 235, //0xEB
-            OKGETPUBKEY: 236,
-            OKSIGN: 237,
-            OKWIPEPRIV: 238,
-            OKSETPRIV: 239,
-            OKDECRYPT: 240,
-            OKRESTORE: 241
-        };
-        this.messageFields = {
-            LABEL: 1,
-            URL: 15,
-            NEXTKEY1: 16,
-            DELAY1: 17,
-            USERNAME: 2,
-            NEXTKEY2: 3,
-            DELAY2: 4,
-            PASSWORD: 5,
-            NEXTKEY3: 6,
-            DELAY3: 7,
-            TFATYPE: 8,
-            TFAUSERNAME: 9,
-            YUBIAUTH: 10,
-            LOCKOUT: 11,
-            WIPEMODE: 12,
-            TYPESPEED: 13,
-            KBDLAYOUT: 14
-        };
-        this.connection = -1;
-        this.isReceivePending = false;
-        this.pollEnabled = false;
-        this.isInitialized = false;
-        this.isLocked = true;
-        this.lastMessages = {
-            sent: [],
-            received: []
-        };
-        this.currentSlotId = null;
-        this.labels = [];
-		this.version = "";
+  function OnlyKey() {
+    this.deviceInfo = {vendorId: 5824, productId: 1158};
+    this.maxInputReportSize = 64;
+    this.maxOutputReportSize = 64;
+    this.maxFeatureReportSize = 0;
+    this.messageHeader = [255, 255, 255, 255];
+    this.messages = {
+      OKSETPIN: 225,       // 0xE1
+      OKSETSDPIN: 226,     // 0xE2
+      OKSETPDPIN: 227,     // 0xE3
+      OKSETTIME: 228,      // 0xE4
+      OKGETLABELS: 229,    // 0xE5
+      OKSETSLOT: 230,      // 0xE6
+      OKWIPESLOT: 231,     // 0xE7
+      OKSETU2FPRIV: 232,   // 0xE8
+      OKWIPEU2FPRIV: 233,  // 0xE9
+      OKSETU2FCERT: 234,   // 0xEA
+      OKWIPEU2FCERT: 235,  // 0xEB
+      OKGETPUBKEY: 236,
+      OKSIGN: 237,
+      OKWIPEPRIV: 238,
+      OKSETPRIV: 239,
+      OKDECRYPT: 240,
+      OKRESTORE: 241
+    };
+    this.messageFields = {
+      LABEL: 1,
+      URL: 15,
+      NEXTKEY1: 16,
+      DELAY1: 17,
+      USERNAME: 2,
+      NEXTKEY2: 3,
+      DELAY2: 4,
+      PASSWORD: 5,
+      NEXTKEY3: 6,
+      DELAY3: 7,
+      TFATYPE: 8,
+      TFAUSERNAME: 9,
+      YUBIAUTH: 10,
+      LOCKOUT: 11,
+      WIPEMODE: 12,
+      TYPESPEED: 13,
+      KBDLAYOUT: 14
+    };
+    this.connection = -1;
+    this.isReceivePending = false;
+    this.pollEnabled = false;
+    this.isInitialized = false;
+    this.isLocked = true;
+    this.lastMessages = {sent: [], received: []};
+    this.currentSlotId = null;
+    this.labels = [];
+    this.version = '';
 
-        this.keyTypeModifiers = {
-            Backup: 128,      // 0x80
-            Signature: 64,    // 0x40
-            Decryption: 32,    // 0x20
-            Authentication: 16 // 0x10
-        };
+    this.keyTypeModifiers = {
+      Backup: 128,        // 0x80
+      Signature: 64,      // 0x40
+      Decryption: 32,     // 0x20
+      Authentication: 16  // 0x10
+    };
+  }
+
+  OnlyKey.prototype.setConnection = function(connectionId) {
+    console.info('Setting connectionId to ' + connectionId);
+    this.connection = connectionId;
+    if (connectionId === -1) {
+      myOnlyKey = new OnlyKey();
+      dialog.open(ui.disconnectedDialog);
+    } else {
+      dialog.open(ui.workingDialog);
+      onlyKeyConfigWizard.init(myOnlyKey);
+    }
+  };
+
+  OnlyKey.prototype.sendMessage = function(options, callback) {
+    var self = this;
+    var bytesPerMessage = 64;
+
+    var msgId =
+        typeof options.msgId === 'string' ? options.msgId.toUpperCase() : null;
+    var slotId = typeof options.slotId === 'number' ||
+            typeof options.slotId === 'string' ?
+        options.slotId :
+        null;
+    var fieldId = typeof options.fieldId === 'string' ||
+            typeof options.fieldId === 'number' ?
+        options.fieldId :
+        null;
+    var contents = typeof options.contents === 'number' ||
+            (options.contents && options.contents.length) ?
+        options.contents :
+        '';
+    var contentType =
+        (options.contentType && options.contentType.toUpperCase()) || 'HEX';
+
+    callback = typeof callback === 'function' ? callback : handleMessage;
+
+    var reportId = 0;
+    var bytes = new Uint8Array(bytesPerMessage);
+    var cursor = 0;
+
+    for (; cursor < self.messageHeader.length; cursor++) {
+      bytes[cursor] = self.messageHeader[cursor];
     }
 
-    OnlyKey.prototype.setConnection = function (connectionId) {
-        console.info("Setting connectionId to " + connectionId);
-        this.connection = connectionId;
-        if (connectionId === -1) {
-            myOnlyKey = new OnlyKey();
-            dialog.open(ui.disconnectedDialog);
-        } else {
-            dialog.open(ui.workingDialog);
-            onlyKeyConfigWizard.init(myOnlyKey);
-        }
-    };
-
-    OnlyKey.prototype.sendMessage = function (options, callback) {
-        var self = this;
-        var bytesPerMessage = 64;
-
-        var msgId = typeof options.msgId === 'string' ? options.msgId.toUpperCase() : null;
-        var slotId = typeof options.slotId === 'number' || typeof options.slotId === 'string' ? options.slotId : null;
-        var fieldId = typeof options.fieldId === 'string' || typeof options.fieldId === 'number' ? options.fieldId : null;
-        var contents = typeof options.contents === 'number' || (options.contents && options.contents.length) ? options.contents : '';
-        var contentType = (options.contentType && options.contentType.toUpperCase()) || 'HEX';
-
-        callback = typeof callback === 'function' ? callback : handleMessage;
-
-        var reportId = 0;
-        var bytes = new Uint8Array(bytesPerMessage);
-        var cursor = 0;
-
-        for (; cursor < self.messageHeader.length; cursor++) {
-            bytes[cursor] = self.messageHeader[cursor];
-        }
-
-        if (msgId && self.messages[msgId]) {
-            bytes[cursor] = strPad(self.messages[msgId], 2, 0);
-            cursor++;
-        }
-
-        if (slotId !== null) {
-            bytes[cursor] = strPad(slotId, 2, 0);
-            cursor++;
-        }
-
-        if (fieldId !== null) {
-            if (self.messageFields[fieldId]) {
-                bytes[cursor] = strPad(self.messageFields[fieldId], 2, 0);
-            } else {
-                bytes[cursor] = fieldId;
-            }
-
-            cursor++;
-        }
-
-        if (!Array.isArray(contents)) {
-            switch(typeof contents) {
-                case 'string':
-                    contents = contents.replace(/\\x([a-fA-F0-9]{2})/g, function (match, capture) {
-                        return String.fromCharCode(parseInt(capture, 16));
-                    });
-
-                    for (var i = 0; i < contents.length && cursor < bytes.length; i++) {
-                        if (contents.charCodeAt(i) > 255) {
-                            throw "I am not smart enough to decode non-ASCII data.";
-                        }
-                        bytes[cursor++] = contents.charCodeAt(i);
-                    }
-                    break;
-                case 'number':
-                    if (contents < 0 || contents > 255) {
-                        throw "Byte value out of bounds.";
-                    }
-                    bytes[cursor++] = contents;
-                    break;
-            }
-        } else {
-            contents.forEach(function (val) {
-                bytes[cursor++] = contentType === 'HEX' ? hexStrToDec(val) : val;
-            });
-        }
-
-        var pad = 0;
-        for (;cursor < bytes.length;) {
-            bytes[cursor++] = pad;
-        }
-
-        console.info("SENDING " + msgId + " to connectionId " + self.connection + ":", bytes);
-
-        chromeHid.send(self.connection, reportId, bytes.buffer, function () {
-            if (chrome.runtime.lastError) {
-                console.error("ERROR SENDING" + (msgId ? " " + msgId : "") + ":", chrome.runtime.lastError, { connectionId: self.connection });
-                callback('ERROR SENDING PACKETS');
-            } else {
-                myOnlyKey.setLastMessage('sent', msgId);
-                callback(null, 'OK');
-            }
-        });
-    };
-
-    OnlyKey.prototype.setLastMessage = function (type, msgStr) {
-        if (msgStr) {
-            var newMessage = { text: msgStr, timestamp: new Date().getTime() };
-            var messages = this.lastMessages[type] || [];
-            var numberToKeep = 3;
-            if (messages.length === numberToKeep) {
-                messages.slice(numberToKeep - 1);
-            }
-            messages = [newMessage].concat(messages);
-            this.lastMessages[type] = messages;
-            if (type === 'received' && onlyKeyConfigWizard) {
-                onlyKeyConfigWizard.setLastMessages(messages);
-            }
-        }
-    };
-
-    OnlyKey.prototype.getLastMessage = function (type) {
-        return this.lastMessages[type] && this.lastMessages[type][0] && this.lastMessages[type][0].hasOwnProperty('text') ? this.lastMessages[type][0].text : '';
-
-    };
-
-    OnlyKey.prototype.listen = function (callback) {
-        pollForInput(callback);
-    };
-
-    OnlyKey.prototype.setTime = function (callback) {
-        var currentEpochTime = Math.round(new Date().getTime() / 1000.0).toString(16);
-        console.info("Setting current epoch time =", currentEpochTime);
-        var timeParts = currentEpochTime.match(/.{2}/g);
-        var options = {
-            contents: timeParts,
-            msgId: 'OKSETTIME'
-        };
-        this.sendMessage(options, callback);
-    };
-
-    OnlyKey.prototype.getLabels = function (callback) {
-        this.labels = 'GETTING';
-        this.sendMessage({ msgId: 'OKGETLABELS' }, handleGetLabels);
-    };
-
-    function handleGetLabels(err, msg) {
-        msg = typeof msg === 'string' ? msg.trim() : '';
-        console.info("HandleGetLabels msg:", msg);
-        if (myOnlyKey.getLastMessage('sent') !== 'OKGETLABELS') {
-            return;
-        }
-
-        if (myOnlyKey.labels === 'GETTING') {
-            myOnlyKey.labels = [];
-            return myOnlyKey.listen(handleGetLabels);
-        }
-
-        // if second char of response is a pipe, theses are labels
-        var msgParts = msg.split('|');
-        var slotNum = parseInt(msgParts[0], 10);
-        if (msg.indexOf('|') !== 2 || typeof slotNum !== 'number' || slotNum < 1 || slotNum > 12) {
-            myOnlyKey.listen(handleGetLabels);
-        } else {
-            myOnlyKey.labels[slotNum - 1] = msgParts[1];
-            initSlotConfigForm();
-            if (slotNum < 12) {
-                myOnlyKey.listen(handleGetLabels);
-            }
-        }
+    if (msgId && self.messages[msgId]) {
+      bytes[cursor] = strPad(self.messages[msgId], 2, 0);
+      cursor++;
     }
 
-    OnlyKey.prototype.sendSetPin = function (callback) {
-        this.sendMessage({ msgId: 'OKSETPIN' }, function (err, msg) {
-            pollForInput(callback);
-        }.bind(this));
-    };
-
-    OnlyKey.prototype.sendSetSDPin = function (callback) {
-        this.sendMessage({ msgId: 'OKSETSDPIN' }, function (err, msg) {
-            pollForInput(callback);
-        }.bind(this));
-    };
-
-    OnlyKey.prototype.sendSetPDPin = function (callback) {
-        this.sendMessage({ msgId: 'OKSETPDPIN' }, function (err, msg) {
-            pollForInput(callback);
-        }.bind(this));
-    };
-
-    OnlyKey.prototype.setSlot = function (slot, field, value, callback) {
-        slot = slot || this.getSlotNum();
-        if (typeof slot !== 'number') slot = this.getSlotNum(slot);
-        var options = {
-            contents: value,
-            msgId: 'OKSETSLOT',
-            slotId: slot,
-            fieldId: field
-        };
-        this.sendMessage(options, callback);
-    };
-
-    OnlyKey.prototype.wipeSlot = function (slot, field, callback) {
-        slot = slot || this.getSlotNum();
-        if (typeof slot !== 'number') slot = this.getSlotNum(slot);
-        var options = {
-            msgId: 'OKWIPESLOT',
-            slotId: slot,
-            fieldId: field || null
-        };
-        this.sendMessage(options, callback);
-    };
-
-    OnlyKey.prototype.getSlotNum = function (slotId) {
-        slotId = slotId || this.currentSlotId;
-        var parts = slotId.split('');
-        return parseInt(parts[0], 10) + (parts[1].toLowerCase() === 'a' ? 0 : 6);
-    };
-
-    OnlyKey.prototype.setYubiAuth = function (publicId, privateId, secretKey, callback) {
-        this.setSlot('XX', 'YUBIAUTH', (publicId+privateId+secretKey).match(/.{2}/g), callback);
-    };
-
-    OnlyKey.prototype.wipeYubiAuth = function (callback) {
-        this.wipeSlot('XX', 'YUBIAUTH', callback);
-    };
-
-    OnlyKey.prototype.setU2fPrivateId = function (privateId, callback) {
-        if (privateId.length) {
-            privateId = privateId.match(/.{2}/g);
-            var options = {
-                contents: privateId,
-                msgId: 'OKSETU2FPRIV'
-            };
-            this.sendMessage(options, callback);
-        } else {
-            callback();
-        }
-    };
-
-    OnlyKey.prototype.wipeU2fPrivateId = function (callback) {
-        this.sendMessage({ msgId: 'OKWIPEU2FPRIV' }, callback);
-    };
-
-    OnlyKey.prototype.setU2fCert = function (cert, packetHeader, callback) {
-        var msg = [ packetHeader ];
-        msg = msg.concat(cert.match(/.{2}/g));
-        var options = {
-            contents: msg,
-            msgId: 'OKSETU2FCERT'
-        };
-        this.sendMessage(options, callback);
-    };
-
-    OnlyKey.prototype.wipeU2fCert = function (callback) {
-        this.sendMessage({ msgId: 'OKWIPEU2FCERT' }, callback);
-    };
-
-    OnlyKey.prototype.setPrivateKey = function (slot, type, key, callback) {
-        var msg, contentType;
-        if (Array.isArray(key)) {
-            // RSA private key is an array of DEC bytes
-            contentType = 'DEC';
-            msg = key;
-        } else {
-            // private key strings should be pairs of HEX bytes
-            msg = key.match(/.{2}/g);
-        }
-
-        var options = {
-            contents: msg,
-            msgId: 'OKSETPRIV',
-            slotId: slot,
-            fieldId: type,
-            contentType: contentType
-        };
-        this.sendMessage(options, callback);
-    };
-
-    OnlyKey.prototype.wipePrivateKey = function (slot, callback) {
-        var options = {
-            msgId: 'OKWIPEPRIV',
-            slotId: slot
-        };
-        this.sendMessage(options, callback);
-    };
-
-    OnlyKey.prototype.restore = function (restoreData, packetHeader, callback) {
-        var msg = [ packetHeader ];
-        msg = msg.concat(restoreData.match(/.{2}/g));
-        var options = {
-            contents: msg,
-            msgId: 'OKRESTORE'
-        };
-        this.sendMessage(options, callback);
-    };
-
-    OnlyKey.prototype.setLockout = function (lockout, callback) {
-        this.setSlot('XX', 'LOCKOUT', lockout, callback);
-    };
-
-    OnlyKey.prototype.setWipeMode = function (wipeMode, callback) {
-        this.setSlot('XX', 'WIPEMODE', wipeMode, callback);
-    };
-
-    OnlyKey.prototype.setTypeSpeed = function (typeSpeed, callback) {
-        this.setSlot('XX', 'TYPESPEED', typeSpeed, callback);
-    };
-
-    OnlyKey.prototype.setKBDLayout = function (kbdLayout, callback) {
-        this.setSlot('XX', 'KBDLAYOUT', kbdLayout, callback);
-    };
-
-	OnlyKey.prototype.setVersion = function (version) {
-		this.version = version;
-	};
-
-	OnlyKey.prototype.getVersion = function () {
-		return this.version;
-	};
-
-    var ui = {
-		showInitPanel: null,
-		showSlotPanel: null,
-        showPrefPanel: null,
-        showKeysPanel: null,
-        showBackupPanel: null,
-        initPanel: null,
-        slotPanel: null,
-        prefPanel: null,
-        keysPanel: null,
-        backupPanel: null,
-        slotConfigBtns: null,
-        lockedDialog: null,
-        slotConfigDialog: null,
-        workingDialog: null,
-        disconnectedDialog: null,
-        main: null
-    };
-
-    var initializeWindow = function () {
-        for (var k in ui) {
-            var id = k.replace(/([A-Z])/g, '-$1').toLowerCase();
-            var element = document.getElementById(id);
-            if (!element) {
-                throw "Missing UI element: " + k + ", " + id;
-            }
-            ui[k] = element;
-        }
-
-        ui.showInitPanel.addEventListener('click', toggleConfigPanel);
-        ui.showSlotPanel.addEventListener('click', toggleConfigPanel);
-        ui.showPrefPanel.addEventListener('click', toggleConfigPanel);
-        ui.showKeysPanel.addEventListener('click', toggleConfigPanel);
-        ui.showBackupPanel.addEventListener('click', toggleConfigPanel);
-
-        ui.yubiAuthForm = document['yubiAuthForm'];
-        ui.u2fAuthForm = document['u2fAuthForm'];
-        ui.lockoutForm = document['lockoutForm'];
-        ui.wipeModeForm = document['wipeModeForm'];
-        ui.typeSpeedForm = document['typeSpeedForm'];
-        ui.keyboardLayoutForm = document['keyboardLayoutForm'];
-        ui.eccForm = document['eccForm'];
-        ui.rsaForm = document['rsaForm'];
-        ui.backupForm = document['backupForm'];
-        ui.restoreForm = document['restoreForm'];
-
-        enableIOControls(false);
-        enableAuthForms();
-        enumerateDevices();
-    };
-
-    var enableIOControls = function (ioEnabled) {
-        closeSlotConfigForm();
-
-        if (!ioEnabled) {
-            ui.main.classList.add('hide');
-            if (myOnlyKey.connection === -1) {
-                dialog.open(ui.disconnectedDialog);
-            }
-        }
-
-        if (myOnlyKey.isInitialized) {
-            if (myOnlyKey.isLocked) {
-                dialog.open(ui.lockedDialog);
-            } else {
-                ui.main.classList.remove('hide');
-                ui.initPanel.classList.add('hide');
-                ui.showInitPanel.classList.remove('hide', 'active');
-                ui.slotPanel.classList.remove('hide');
-                ui.showSlotPanel.classList.remove('hide');
-                ui.showSlotPanel.classList.add('active');
-                ui.prefPanel.classList.add('hide');
-                ui.showPrefPanel.classList.remove('hide', 'active');
-                ui.keysPanel.classList.add('hide');
-                ui.showKeysPanel.classList.remove('hide', 'active');
-                ui.backupPanel.classList.add('hide');
-                ui.backupPanel.classList.remove('active');
-                ui.keysPanel.classList.add('hide');
-                ui.keysPanel.classList.remove('active');
-                ui.showBackupPanel.classList.remove('hide', 'active');
-                dialog.close(ui.lockedDialog);
-            }
-        } else {
-            ui.main.classList.remove('hide');
-            ui.slotPanel.classList.add('hide');
-            ui.slotPanel.classList.remove('active');
-            ui.backupPanel.classList.add('hide');
-            ui.backupPanel.classList.remove('active');
-            ui.keysPanel.classList.add('hide');
-            ui.keysPanel.classList.remove('active');
-			ui.prefPanel.classList.add('hide');
-			ui.prefPanel.classList.remove('active');
-            ui.initPanel.classList.remove('hide');
-            ui.showInitPanel.classList.remove('hide');
-            ui.showInitPanel.classList.add('active');
-            ui.showSlotPanel.classList.add('hide');
-            ui.showPrefPanel.classList.add('hide');
-            ui.showKeysPanel.classList.add('hide');
-            ui.showBackupPanel.classList.add('hide');
-            dialog.close(ui.lockedDialog);
-        }
-    };
-
-    var enumerateDevices = function () {
-        chromeHid.getDevices(myOnlyKey.deviceInfo, onDevicesEnumerated);
-        chromeHid.onDeviceAdded.addListener(onDeviceAdded);
-        chromeHid.onDeviceRemoved.addListener(onDeviceRemoved);
-    };
-
-    var onDevicesEnumerated = function (devices) {
-        if (chrome.runtime.lastError) {
-            console.error("onDevicesEnumerated ERROR:", chrome.runtime.lastError);
-            return;
-        }
-
-        console.info("HID devices:", devices);
-
-        for (var device of devices) {
-            onDeviceAdded(device);
-        }
-    };
-
-    var onDeviceAdded = function (device) {
-        // auto connect desired device
-        if (device.maxInputReportSize === myOnlyKey.maxInputReportSize &&
-            device.maxOutputReportSize === myOnlyKey.maxOutputReportSize &&
-            device.maxFeatureReportSize === myOnlyKey.maxFeatureReportSize) {
-            connectDevice(device.deviceId);
-        }
-    };
-
-    var connectDevice = function (deviceId) {
-        console.info('CONNECTING deviceId:', deviceId);
-
-        dialog.close(ui.disconnectedDialog);
-        dialog.open(ui.workingDialog);
-
-        chromeHid.connect(deviceId, function (connectInfo) {
-            if (chrome.runtime.lastError) {
-                console.error("ERROR CONNECTING:", chrome.runtime.lastError);
-            } else if (!connectInfo) {
-                console.warn("Unable to connect to device.");
-            } else {
-                console.info("CONNECTINFO:", connectInfo);
-            }
-
-            myOnlyKey.setConnection(connectInfo.connectionId);
-            myOnlyKey.setTime(pollForInput);
-            enableIOControls(true);
-        });
-    };
-
-    var onDeviceRemoved = function () {
-        console.info("ONDEVICEREMOVED was triggered with connectionId", myOnlyKey.connection);
-        if (myOnlyKey.connection === -1) return handleDisconnect();
-
-        chromeHid.disconnect(myOnlyKey.connection, function () {
-            if (chrome.runtime.lastError) {
-                console.warn('DISCONNECT ERROR:', chrome.runtime.lastError);
-            }
-            console.info("DISCONNECTED CONNECTION", myOnlyKey.connection);
-            handleDisconnect();
-        });
-    };
-
-    function handleDisconnect() {
-        myOnlyKey.setConnection(-1);
-        myOnlyKey.setLastMessage('received', 'Disconnected');
-        onlyKeyConfigWizard.initForm.reset();
-        enableIOControls(false);
+    if (slotId !== null) {
+      bytes[cursor] = strPad(slotId, 2, 0);
+      cursor++;
     }
 
-    var pollForInput = function (callback) {
-        console.info("Polling...");
-        clearTimeout(myOnlyKey.poll);
-        callback = callback || handleMessage;
+    if (fieldId !== null) {
+      if (self.messageFields[fieldId]) {
+        bytes[cursor] = strPad(self.messageFields[fieldId], 2, 0);
+      } else {
+        bytes[cursor] = fieldId;
+      }
 
-        var msg;
-        chromeHid.receive(myOnlyKey.connection, function (reportId, data) {
-            if (chrome.runtime.lastError) {
-                myOnlyKey.setLastMessage('received', '[error]');
-                return callback(chrome.runtime.lastError);
-            } else {
-                msg = readBytes(new Uint8Array(data));
+      cursor++;
+    }
+
+    if (!Array.isArray(contents)) {
+      switch (typeof contents) {
+        case 'string':
+          contents = contents.replace(
+              /\\x([a-fA-F0-9]{2})/g, function(match, capture) {
+                return String.fromCharCode(parseInt(capture, 16));
+              });
+
+          for (var i = 0; i < contents.length && cursor < bytes.length; i++) {
+            if (contents.charCodeAt(i) > 255) {
+              throw 'I am not smart enough to decode non-ASCII data.';
             }
+            bytes[cursor++] = contents.charCodeAt(i);
+          }
+          break;
+        case 'number':
+          if (contents < 0 || contents > 255) {
+            throw 'Byte value out of bounds.';
+          }
+          bytes[cursor++] = contents;
+          break;
+      }
+    } else {
+      contents.forEach(function(val) {
+        bytes[cursor++] = contentType === 'HEX' ? hexStrToDec(val) : val;
+      });
+    }
 
-            console.info("RECEIVED:", msg);
+    var pad = 0;
+    for (; cursor < bytes.length;) {
+      bytes[cursor++] = pad;
+    }
 
-            if (myOnlyKey.pollEnabled) {
-                myOnlyKey.poll = setTimeout(pollForInput, 0);
-            }
+    console.info(
+        'SENDING ' + msgId + ' to connectionId ' + self.connection + ':',
+        bytes);
 
-            if (msg.length > 1 && msg !== 'OK') {
-                myOnlyKey.setLastMessage('received', msg);
-            }
+    chromeHid.send(self.connection, reportId, bytes.buffer, function() {
+      if (chrome.runtime.lastError) {
+        console.error(
+            'ERROR SENDING' + (msgId ? ' ' + msgId : '') + ':',
+            chrome.runtime.lastError, {connectionId: self.connection});
+        callback('ERROR SENDING PACKETS');
+      } else {
+        myOnlyKey.setLastMessage('sent', msgId);
+        callback(null, 'OK');
+      }
+    });
+  };
 
-            // if message begins with Error, call callback with msg as err
-            // and the last sent message as 2nd arg
-            if (msg.indexOf("Error") === 0) {
-                return callback(msg, myOnlyKey.getLastMessage('sent'));
-            }
+  OnlyKey.prototype.setLastMessage = function(type, msgStr) {
+    if (msgStr) {
+      var newMessage = {text: msgStr, timestamp: new Date().getTime()};
+      var messages = this.lastMessages[type] || [];
+      var numberToKeep = 3;
+      if (messages.length === numberToKeep) {
+        messages.slice(numberToKeep - 1);
+      }
+      messages = [newMessage].concat(messages);
+      this.lastMessages[type] = messages;
+      if (type === 'received' && onlyKeyConfigWizard) {
+        onlyKeyConfigWizard.setLastMessages(messages);
+      }
+    }
+  };
 
-            // else call callback with null err and msg as 2nd arg
-            return callback(null, msg);
-        });
+  OnlyKey.prototype.getLastMessage = function(type) {
+    return this.lastMessages[type] && this.lastMessages[type][0] &&
+            this.lastMessages[type][0].hasOwnProperty('text') ?
+        this.lastMessages[type][0].text :
+        '';
+
+  };
+
+  OnlyKey.prototype.listen = function(callback) {
+    pollForInput(callback);
+  };
+
+  OnlyKey.prototype.setTime = function(callback) {
+    var currentEpochTime =
+        Math.round(new Date().getTime() / 1000.0).toString(16);
+    console.info('Setting current epoch time =', currentEpochTime);
+    var timeParts = currentEpochTime.match(/.{2}/g);
+    var options = {contents: timeParts, msgId: 'OKSETTIME'};
+    this.sendMessage(options, callback);
+  };
+
+  OnlyKey.prototype.getLabels = function(callback) {
+    this.labels = 'GETTING';
+    this.sendMessage({msgId: 'OKGETLABELS'}, handleGetLabels);
+  };
+
+  function handleGetLabels(err, msg) {
+    msg = typeof msg === 'string' ? msg.trim() : '';
+    console.info('HandleGetLabels msg:', msg);
+    if (myOnlyKey.getLastMessage('sent') !== 'OKGETLABELS') {
+      return;
+    }
+
+    if (myOnlyKey.labels === 'GETTING') {
+      myOnlyKey.labels = [];
+      return myOnlyKey.listen(handleGetLabels);
+    }
+
+    // if second char of response is a pipe, theses are labels
+    var msgParts = msg.split('|');
+    var slotNum = parseInt(msgParts[0], 10);
+    if (msg.indexOf('|') !== 2 || typeof slotNum !== 'number' || slotNum < 1 ||
+        slotNum > 12) {
+      myOnlyKey.listen(handleGetLabels);
+    } else {
+      myOnlyKey.labels[slotNum - 1] = msgParts[1];
+      initSlotConfigForm();
+      if (slotNum < 12) {
+        myOnlyKey.listen(handleGetLabels);
+      }
+    }
+  }
+
+  OnlyKey.prototype.sendSetPin = function(callback) {
+    this.sendMessage({msgId: 'OKSETPIN'}, function(err, msg) {
+      pollForInput(callback);
+    }.bind(this));
+  };
+
+  OnlyKey.prototype.sendSetSDPin = function(callback) {
+    this.sendMessage({msgId: 'OKSETSDPIN'}, function(err, msg) {
+      pollForInput(callback);
+    }.bind(this));
+  };
+
+  OnlyKey.prototype.sendSetPDPin = function(callback) {
+    this.sendMessage({msgId: 'OKSETPDPIN'}, function(err, msg) {
+      pollForInput(callback);
+    }.bind(this));
+  };
+
+  OnlyKey.prototype.setSlot = function(slot, field, value, callback) {
+    slot = slot || this.getSlotNum();
+    if (typeof slot !== 'number') slot = this.getSlotNum(slot);
+    var options =
+        {contents: value, msgId: 'OKSETSLOT', slotId: slot, fieldId: field};
+    this.sendMessage(options, callback);
+  };
+
+  OnlyKey.prototype.wipeSlot = function(slot, field, callback) {
+    slot = slot || this.getSlotNum();
+    if (typeof slot !== 'number') slot = this.getSlotNum(slot);
+    var options = {msgId: 'OKWIPESLOT', slotId: slot, fieldId: field || null};
+    this.sendMessage(options, callback);
+  };
+
+  OnlyKey.prototype.getSlotNum = function(slotId) {
+    slotId = slotId || this.currentSlotId;
+    var parts = slotId.split('');
+    return parseInt(parts[0], 10) + (parts[1].toLowerCase() === 'a' ? 0 : 6);
+  };
+
+  OnlyKey.prototype.setYubiAuth = function(
+      publicId, privateId, secretKey, callback) {
+    this.setSlot(
+        'XX', 'YUBIAUTH', (publicId + privateId + secretKey).match(/.{2}/g),
+        callback);
+  };
+
+  OnlyKey.prototype.wipeYubiAuth = function(callback) {
+    this.wipeSlot('XX', 'YUBIAUTH', callback);
+  };
+
+  OnlyKey.prototype.setU2fPrivateId = function(privateId, callback) {
+    if (privateId.length) {
+      privateId = privateId.match(/.{2}/g);
+      var options = {contents: privateId, msgId: 'OKSETU2FPRIV'};
+      this.sendMessage(options, callback);
+    } else {
+      callback();
+    }
+  };
+
+  OnlyKey.prototype.wipeU2fPrivateId = function(callback) {
+    this.sendMessage({msgId: 'OKWIPEU2FPRIV'}, callback);
+  };
+
+  OnlyKey.prototype.setU2fCert = function(cert, packetHeader, callback) {
+    var msg = [packetHeader];
+    msg = msg.concat(cert.match(/.{2}/g));
+    var options = {contents: msg, msgId: 'OKSETU2FCERT'};
+    this.sendMessage(options, callback);
+  };
+
+  OnlyKey.prototype.wipeU2fCert = function(callback) {
+    this.sendMessage({msgId: 'OKWIPEU2FCERT'}, callback);
+  };
+
+  OnlyKey.prototype.setPrivateKey = function(slot, type, key, callback) {
+    var msg, contentType;
+    if (Array.isArray(key)) {
+      // RSA private key is an array of DEC bytes
+      contentType = 'DEC';
+      msg = key;
+    } else {
+      // private key strings should be pairs of HEX bytes
+      msg = key.match(/.{2}/g);
+    }
+
+    var options = {
+      contents: msg,
+      msgId: 'OKSETPRIV',
+      slotId: slot,
+      fieldId: type,
+      contentType: contentType
     };
+    this.sendMessage(options, callback);
+  };
 
-    var readBytes = function (bytes) {
-        var msgStr = '';
-        var msgBytes = new Uint8Array(bytes.buffer);
+  OnlyKey.prototype.wipePrivateKey = function(slot, callback) {
+    var options = {msgId: 'OKWIPEPRIV', slotId: slot};
+    this.sendMessage(options, callback);
+  };
 
-        for (var i = 0; i < msgBytes.length; i++) {
-            if (msgBytes[i] > 31 && msgBytes[i] < 127)
-                msgStr += String.fromCharCode(msgBytes[i]);
-            else if (i === 0)
-                // if first byte is a hex, this is probably a slot number
-                msgStr += byteToHex(msgBytes[i]);
+  OnlyKey.prototype.restore = function(restoreData, packetHeader, callback) {
+    var msg = [packetHeader];
+    msg = msg.concat(restoreData.match(/.{2}/g));
+    var options = {contents: msg, msgId: 'OKRESTORE'};
+    this.sendMessage(options, callback);
+  };
+
+  OnlyKey.prototype.setLockout = function(lockout, callback) {
+    this.setSlot('XX', 'LOCKOUT', lockout, callback);
+  };
+
+  OnlyKey.prototype.setWipeMode = function(wipeMode, callback) {
+    this.setSlot('XX', 'WIPEMODE', wipeMode, callback);
+  };
+
+  OnlyKey.prototype.setTypeSpeed = function(typeSpeed, callback) {
+    this.setSlot('XX', 'TYPESPEED', typeSpeed, callback);
+  };
+
+  OnlyKey.prototype.setKBDLayout = function(kbdLayout, callback) {
+    this.setSlot('XX', 'KBDLAYOUT', kbdLayout, callback);
+  };
+
+  OnlyKey.prototype.setVersion = function(version) {
+    this.version = version;
+  };
+
+  OnlyKey.prototype.getVersion = function() {
+    return this.version;
+  };
+
+  var ui = {
+    showInitPanel: null,
+    showSlotPanel: null,
+    showPrefPanel: null,
+    showKeysPanel: null,
+    showBackupPanel: null,
+    initPanel: null,
+    slotPanel: null,
+    prefPanel: null,
+    keysPanel: null,
+    backupPanel: null,
+    slotConfigBtns: null,
+    lockedDialog: null,
+    slotConfigDialog: null,
+    workingDialog: null,
+    disconnectedDialog: null,
+    main: null
+  };
+
+  var initializeWindow = function() {
+    for (var k in ui) {
+      var id = k.replace(/([A-Z])/g, '-$1').toLowerCase();
+      var element = document.getElementById(id);
+      if (!element) {
+        throw 'Missing UI element: ' + k + ', ' + id;
+      }
+      ui[k] = element;
+    }
+
+    ui.showInitPanel.addEventListener('click', toggleConfigPanel);
+    ui.showSlotPanel.addEventListener('click', toggleConfigPanel);
+    ui.showPrefPanel.addEventListener('click', toggleConfigPanel);
+    ui.showKeysPanel.addEventListener('click', toggleConfigPanel);
+    ui.showBackupPanel.addEventListener('click', toggleConfigPanel);
+
+    ui.yubiAuthForm = document['yubiAuthForm'];
+    ui.u2fAuthForm = document['u2fAuthForm'];
+    ui.lockoutForm = document['lockoutForm'];
+    ui.wipeModeForm = document['wipeModeForm'];
+    ui.typeSpeedForm = document['typeSpeedForm'];
+    ui.keyboardLayoutForm = document['keyboardLayoutForm'];
+    ui.eccForm = document['eccForm'];
+    ui.rsaForm = document['rsaForm'];
+    ui.backupForm = document['backupForm'];
+    ui.restoreForm = document['restoreForm'];
+
+    enableIOControls(false);
+    enableAuthForms();
+    enumerateDevices();
+  };
+
+  var enableIOControls = function(ioEnabled) {
+    closeSlotConfigForm();
+
+    if (!ioEnabled) {
+      ui.main.classList.add('hide');
+      if (myOnlyKey.connection === -1) {
+        dialog.open(ui.disconnectedDialog);
+      }
+    }
+
+    if (myOnlyKey.isInitialized) {
+      if (myOnlyKey.isLocked) {
+        dialog.open(ui.lockedDialog);
+      } else {
+        ui.main.classList.remove('hide');
+        ui.initPanel.classList.add('hide');
+        ui.showInitPanel.classList.remove('hide', 'active');
+        ui.slotPanel.classList.remove('hide');
+        ui.showSlotPanel.classList.remove('hide');
+        ui.showSlotPanel.classList.add('active');
+        ui.prefPanel.classList.add('hide');
+        ui.showPrefPanel.classList.remove('hide', 'active');
+        ui.keysPanel.classList.add('hide');
+        ui.showKeysPanel.classList.remove('hide', 'active');
+        ui.backupPanel.classList.add('hide');
+        ui.backupPanel.classList.remove('active');
+        ui.keysPanel.classList.add('hide');
+        ui.keysPanel.classList.remove('active');
+        ui.showBackupPanel.classList.remove('hide', 'active');
+        dialog.close(ui.lockedDialog);
+      }
+    } else {
+      ui.main.classList.remove('hide');
+      ui.slotPanel.classList.add('hide');
+      ui.slotPanel.classList.remove('active');
+      ui.backupPanel.classList.add('hide');
+      ui.backupPanel.classList.remove('active');
+      ui.keysPanel.classList.add('hide');
+      ui.keysPanel.classList.remove('active');
+      ui.prefPanel.classList.add('hide');
+      ui.prefPanel.classList.remove('active');
+      ui.initPanel.classList.remove('hide');
+      ui.showInitPanel.classList.remove('hide');
+      ui.showInitPanel.classList.add('active');
+      ui.showSlotPanel.classList.add('hide');
+      ui.showPrefPanel.classList.add('hide');
+      ui.showKeysPanel.classList.add('hide');
+      ui.showBackupPanel.classList.add('hide');
+      dialog.close(ui.lockedDialog);
+    }
+  };
+
+  var enumerateDevices = function() {
+    chromeHid.getDevices(myOnlyKey.deviceInfo, onDevicesEnumerated);
+    chromeHid.onDeviceAdded.addListener(onDeviceAdded);
+    chromeHid.onDeviceRemoved.addListener(onDeviceRemoved);
+  };
+
+  var onDevicesEnumerated = function(devices) {
+    if (chrome.runtime.lastError) {
+      console.error('onDevicesEnumerated ERROR:', chrome.runtime.lastError);
+      return;
+    }
+
+    console.info('HID devices:', devices);
+
+    for (var device of devices) {
+      onDeviceAdded(device);
+    }
+  };
+
+  var onDeviceAdded = function(device) {
+    // auto connect desired device
+    if (device.maxInputReportSize === myOnlyKey.maxInputReportSize &&
+        device.maxOutputReportSize === myOnlyKey.maxOutputReportSize &&
+        device.maxFeatureReportSize === myOnlyKey.maxFeatureReportSize) {
+      connectDevice(device.deviceId);
+    }
+  };
+
+  var connectDevice = function(deviceId) {
+    console.info('CONNECTING deviceId:', deviceId);
+
+    dialog.close(ui.disconnectedDialog);
+    dialog.open(ui.workingDialog);
+
+    chromeHid.connect(deviceId, function(connectInfo) {
+      if (chrome.runtime.lastError) {
+        console.error('ERROR CONNECTING:', chrome.runtime.lastError);
+      } else if (!connectInfo) {
+        console.warn('Unable to connect to device.');
+      } else {
+        console.info('CONNECTINFO:', connectInfo);
+      }
+
+      myOnlyKey.setConnection(connectInfo.connectionId);
+      myOnlyKey.setTime(pollForInput);
+      enableIOControls(true);
+    });
+  };
+
+  var onDeviceRemoved = function() {
+    console.info(
+        'ONDEVICEREMOVED was triggered with connectionId',
+        myOnlyKey.connection);
+    if (myOnlyKey.connection === -1) return handleDisconnect();
+
+    chromeHid.disconnect(myOnlyKey.connection, function() {
+      if (chrome.runtime.lastError) {
+        console.warn('DISCONNECT ERROR:', chrome.runtime.lastError);
+      }
+      console.info('DISCONNECTED CONNECTION', myOnlyKey.connection);
+      handleDisconnect();
+    });
+  };
+
+  function handleDisconnect() {
+    myOnlyKey.setConnection(-1);
+    myOnlyKey.setLastMessage('received', 'Disconnected');
+    onlyKeyConfigWizard.initForm.reset();
+    enableIOControls(false);
+  }
+
+  var pollForInput = function(callback) {
+    console.info('Polling...');
+    clearTimeout(myOnlyKey.poll);
+    callback = callback || handleMessage;
+
+    var msg;
+    chromeHid.receive(myOnlyKey.connection, function(reportId, data) {
+      if (chrome.runtime.lastError) {
+        myOnlyKey.setLastMessage('received', '[error]');
+        return callback(chrome.runtime.lastError);
+      } else {
+        msg = readBytes(new Uint8Array(data));
+      }
+
+      console.info('RECEIVED:', msg);
+
+      if (myOnlyKey.pollEnabled) {
+        myOnlyKey.poll = setTimeout(pollForInput, 0);
+      }
+
+      if (msg.length > 1 && msg !== 'OK') {
+        myOnlyKey.setLastMessage('received', msg);
+      }
+
+      // if message begins with Error, call callback with msg as err
+      // and the last sent message as 2nd arg
+      if (msg.indexOf('Error') === 0) {
+        return callback(msg, myOnlyKey.getLastMessage('sent'));
+      }
+
+      // else call callback with null err and msg as 2nd arg
+      return callback(null, msg);
+    });
+  };
+
+  var readBytes = function(bytes) {
+    var msgStr = '';
+    var msgBytes = new Uint8Array(bytes.buffer);
+
+    for (var i = 0; i < msgBytes.length; i++) {
+      if (msgBytes[i] > 31 && msgBytes[i] < 127)
+        msgStr += String.fromCharCode(msgBytes[i]);
+      else if (i === 0)
+        // if first byte is a hex, this is probably a slot number
+        msgStr += byteToHex(msgBytes[i]);
+    }
+
+    return msgStr;
+  };
+
+  var handleMessage = function(err, msg) {
+    if (err) {
+      return console.error('MESSAGE ERROR:', err);
+    }
+
+    msg = msg.trim();
+    var updateUI = false;
+    dialog.close(ui.workingDialog);
+
+    switch (msg) {
+      case 'UNINITIALIZED':
+      case 'INITIALIZED':
+        myOnlyKey.isInitialized = (msg === 'INITIALIZED');
+        updateUI = true;
+
+        // special handling if last message sent was PIN-related
+        switch (myOnlyKey.getLastMessage('sent')) {
+          case 'OKSETPIN':
+          case 'OKSETPDPIN':
+          case 'OKSETSDPIN':
+            return pollForInput();
         }
 
-        return msgStr;
-    };
+        break;
+      default:
+        break;
+    }
 
-    var handleMessage = function (err, msg) {
-        if (err) {
-            return console.error("MESSAGE ERROR:", err);
-        }
+    if (msg === 'INITIALIZED' &&
+        !myOnlyKey.pollEnabled) {  // OK should still be locked
+      pollForInput();
+    }
 
-        msg = msg.trim();
-        var updateUI = false;
-        dialog.close(ui.workingDialog);
-
-        switch (msg) {
-            case "UNINITIALIZED":
-            case "INITIALIZED":
-                myOnlyKey.isInitialized = (msg === "INITIALIZED");
-                updateUI = true;
-
-                // special handling if last message sent was PIN-related
-                switch (myOnlyKey.getLastMessage('sent')) {
-                    case 'OKSETPIN':
-                    case 'OKSETPDPIN':
-                    case 'OKSETSDPIN':
-                        return pollForInput();
-                }
-
-                break;
-            default:
-                break;
-        }
-
-        if (msg === "INITIALIZED" && !myOnlyKey.pollEnabled) { // OK should still be locked
-            pollForInput();
-        }
-
-        if (msg.indexOf("UNLOCKED") >= 0) {
-            if ( myOnlyKey.getLastMessage('sent') === 'OKSETPRIV' ) {
-                pollForInput();
-            } else {
-                myOnlyKey.isInitialized = true;
-                myOnlyKey.setVersion(msg.split("UNLOCKED").pop());
-                setOkVersionStr();
-                if (myOnlyKey.isLocked) {
-                    myOnlyKey.isLocked = false;
-                    myOnlyKey.getLabels(pollForInput);
-                    updateUI = true;
-                }
-            }
-        } else if (msg.indexOf("LOCKED") >= 0) {
-            myOnlyKey.isLocked = true;
-        }
-
-        if (updateUI) {
-            enableIOControls(true);
-        }
-    };
-
-    var enablePolling = function () {
-        myOnlyKey.pollEnabled = true;
+    if (msg.indexOf('UNLOCKED') >= 0) {
+      if (myOnlyKey.getLastMessage('sent') === 'OKSETPRIV') {
         pollForInput();
+      } else {
+        myOnlyKey.isInitialized = true;
+        myOnlyKey.setVersion(msg.split('UNLOCKED').pop());
+        setOkVersionStr();
+        if (myOnlyKey.isLocked) {
+          myOnlyKey.isLocked = false;
+          myOnlyKey.getLabels(pollForInput);
+          updateUI = true;
+        }
+      }
+    } else if (msg.indexOf('LOCKED') >= 0) {
+      myOnlyKey.isLocked = true;
+    }
+
+    if (updateUI) {
+      enableIOControls(true);
+    }
+  };
+
+  var enablePolling = function() {
+    myOnlyKey.pollEnabled = true;
+    pollForInput();
+  };
+
+  function init() {
+    console.info('OnlyKeyComm init() called');
+    initializeWindow();
+    myOnlyKey.setConnection(-1);
+  }
+
+  function toggleConfigPanel(e) {
+    var clicked = this;
+    var panels = {
+      init: 'Init',
+      slot: 'Slot',
+      pref: 'Pref',
+      keys: 'Keys',
+      backup: 'Backup'
+    };
+    var hiddenClass = 'hide';
+    var activeClass = 'active';
+    for (var panel in panels) {
+      if (clicked.id.indexOf(panel) >= 0) {
+        ui[panel + 'Panel'].classList.remove(hiddenClass);
+        ui['show' + panels[panel] + 'Panel'].classList.add(activeClass);
+      } else {
+        ui[panel + 'Panel'].classList.add(hiddenClass);
+        ui['show' + panels[panel] + 'Panel'].classList.remove(activeClass);
+      }
+    }
+    e && e.preventDefault && e.preventDefault();
+  }
+
+  function initSlotConfigForm() {
+    var configBtns =
+        Array.from(ui.slotConfigBtns.getElementsByTagName('input'));
+    configBtns.forEach(function(btn, i) {
+      var labelIndex = myOnlyKey.getSlotNum(btn.value);
+      var labelText = myOnlyKey.labels[labelIndex - 1] || 'empty';
+      onlyKeyConfigWizard.setSlotLabel(i, labelText);
+      btn.addEventListener('click', showSlotConfigForm);
+    });
+    ui.slotConfigDialog.getElementsByClassName('slot-config-close')[0]
+        .addEventListener('click', closeSlotConfigForm);
+  }
+
+  function showSlotConfigForm(e) {
+    var slotId = e.target.value;
+    myOnlyKey.currentSlotId = slotId;
+    var slotLabel = document.getElementById('slotLabel' + slotId).innerText;
+    ui.slotConfigDialog.getElementsByClassName('slotId')[0].innerText = slotId;
+
+    document.getElementById('txtSlotLabel').value =
+        slotLabel.toLowerCase() === 'empty' ? '' : slotLabel;
+    dialog.open(ui.slotConfigDialog);
+    initSlotConfigForm();
+    e && e.preventDefault && e.preventDefault();
+  }
+
+  function closeSlotConfigForm(e) {
+    dialog.close(ui.slotConfigDialog);
+    e && e.preventDefault && e.preventDefault();
+  }
+
+  function enableAuthForms() {
+    var yubiSubmit = document.getElementById('yubiSubmit');
+    var yubiWipe = document.getElementById('yubiWipe');
+    yubiSubmit.addEventListener('click', submitYubiAuthForm);
+    yubiWipe.addEventListener('click', wipeYubiAuthForm);
+
+    var u2fSubmit = document.getElementById('u2fSubmit');
+    var u2fWipe = document.getElementById('u2fWipe');
+    u2fSubmit.addEventListener('click', submitU2fAuthForm);
+    u2fWipe.addEventListener('click', wipeU2fAuthForm);
+
+    var lockoutSubmit = document.getElementById('lockoutSubmit');
+    lockoutSubmit.addEventListener('click', submitLockoutForm);
+
+    var wipeModeSubmit = document.getElementById('wipeModeSubmit');
+    wipeModeSubmit.addEventListener('click', submitWipeModeForm);
+
+    var typeSpeedSubmit = document.getElementById('typeSpeedSubmit');
+    typeSpeedSubmit.addEventListener('click', submitTypeSpeedForm);
+
+    var kbdLayoutSubmit = document.getElementById('kbdLayoutSubmit');
+    kbdLayoutSubmit.addEventListener('click', submitKBDLayoutForm);
+
+    var eccSubmit = document.getElementById('eccSubmit');
+    eccSubmit.addEventListener('click', submitEccForm);
+    ui.eccForm.setError = function(errString) {
+      document.getElementById('eccFormError').innerText = errString;
     };
 
-    function init() {
-        console.info("OnlyKeyComm init() called");
-        initializeWindow();
-        myOnlyKey.setConnection(-1);
+    var eccWipe = document.getElementById('eccWipe');
+    eccWipe.addEventListener('click', wipeEccKeyForm);
+
+    var rsaSubmit = document.getElementById('rsaSubmit');
+    rsaSubmit.addEventListener('click', submitRsaForm);
+    ui.rsaForm.setError = function(errString) {
+      document.getElementById('rsaFormError').innerText = errString;
+    };
+
+    var rsaWipe = document.getElementById('rsaWipe');
+    rsaWipe.addEventListener('click', wipeRsaKeyForm);
+
+    var backupSave = document.getElementById('backupSave');
+    backupSave.addEventListener('click', saveBackupFile);
+    ui.backupForm.setError = function(errString) {
+      document.getElementById('backupFormError').innerText = errString;
+    };
+
+    var restoreFromBackup = document.getElementById('doRestore');
+    restoreFromBackup.addEventListener('click', submitRestoreForm);
+    ui.restoreForm.setError = function(errString) {
+      document.getElementById('restoreFormError').innerText = errString;
+    };
+
+    ui.backupForm.setError('');
+    ui.backupForm.reset();
+    ui.restoreForm.setError('');
+    ui.restoreForm.reset();
+  }
+
+  function submitYubiAuthForm(e) {
+    var publicId = ui.yubiAuthForm.yubiPublicId.value || '';
+    var privateId = ui.yubiAuthForm.yubiPrivateId.value || '';
+    var secretKey = ui.yubiAuthForm.yubiSecretKey.value || '';
+
+    publicId = publicId.toString().replace(/\s/g, '');
+    privateId = privateId.toString().replace(/\s/g, '');
+    secretKey = secretKey.toString().replace(/\s/g, '');
+
+    // going to be mean and only send the max chars allowed
+    var maxPublicIdLength = 12;   // 6 bytes
+    var maxPrivateIdLength = 12;  // 6 bytes
+    var maxSecretKeyLength = 32;  // 64 bytes
+    publicId = hexToModhex(publicId.slice(0, maxPublicIdLength), true);
+    privateId = privateId.slice(0, maxPrivateIdLength);
+    secretKey = secretKey.slice(0, maxSecretKeyLength);
+
+    // TODO: validation
+    myOnlyKey.setYubiAuth(publicId, privateId, secretKey, function(err) {
+      // TODO: check for success, then reset
+      ui.yubiAuthForm.reset();
+    });
+
+    e && e.preventDefault && e.preventDefault();
+  }
+
+  function wipeYubiAuthForm(e) {
+    myOnlyKey.wipeYubiAuth();
+    e && e.preventDefault && e.preventDefault();
+  }
+
+  function submitU2fAuthForm(e) {
+    var privateId = ui.u2fAuthForm.u2fPrivateId.value || '';
+    var cert = ui.u2fAuthForm.u2fCert.value || '';
+
+    privateId = privateId.toString().replace(/\s/g, '');
+    cert = cert.toString().replace(/\s/g, '');
+
+    // going to be mean and only send the max chars allowed
+    var maxPrivateIdLength = 64;  // 32 bytes
+    var maxCertLength = 2048;     // 1024 bytes
+    privateId = privateId.slice(0, maxPrivateIdLength);
+    cert = cert.slice(0, maxCertLength);
+
+    // TODO: validation
+    myOnlyKey.setU2fPrivateId(privateId, function(err) {
+      submitU2fCert(cert, function(err) {
+        // TODO: check for success, then reset
+        ui.u2fAuthForm.reset();
+      });
+    });
+
+    e && e.preventDefault && e.preventDefault();
+  }
+
+  function submitU2fCert(certStr, callback) {
+    // this function should recursively call itself until all bytes are sent in
+    // chunks
+    if (!certStr.length) {
+      return callback();
     }
 
-    function toggleConfigPanel(e) {
-		var clicked = this;
-		var panels = {
-			init: "Init",
-			slot: "Slot",
-            pref: "Pref",
-            keys: "Keys",
-            backup: "Backup"
-		};
-		var hiddenClass = 'hide';
-		var activeClass = 'active';
-		for (var panel in panels) {
-			if (clicked.id.indexOf(panel) >= 0) {
-				ui[panel + "Panel"].classList.remove(hiddenClass);
-				ui["show" + panels[panel] + "Panel"].classList.add(activeClass);
-			} else {
-				ui[panel + "Panel"].classList.add(hiddenClass);
-				ui["show" + panels[panel] + "Panel"].classList.remove(activeClass);
-			}
-		}
-        e && e.preventDefault && e.preventDefault();
+    var maxPacketSize = 116;  // 58 byte pairs
+    var finalPacket = certStr.length - maxPacketSize <= 0;
+
+    var cb = finalPacket ?
+        callback :
+        submitU2fCert.bind(null, certStr.slice(maxPacketSize), callback);
+
+    // packetHeader is hex number of bytes in certStr chunk
+    var packetHeader = finalPacket ? (certStr.length / 2).toString(16) : 'FF';
+
+    myOnlyKey.setU2fCert(certStr.slice(0, maxPacketSize), packetHeader, cb);
+  }
+
+  function wipeU2fAuthForm(e) {
+    myOnlyKey.wipeU2fPrivateId(function(err) {
+      myOnlyKey.wipeU2fCert();
+    });
+
+    e && e.preventDefault && e.preventDefault();
+  }
+
+  function submitEccForm(e) {
+    ui.eccForm.setError('');
+
+    var type = parseInt(ui.eccForm.eccType.value || '', 10);
+    var slot = parseInt(ui.eccForm.eccSlot.value || '', 10);
+    var key = ui.eccForm.eccKey.value || '';
+
+    var maxKeyLength = 64;  // 32 hex pairs
+
+    key = key.toString().replace(/\s/g, '').slice(0, maxKeyLength);
+
+    if (!key) {
+      return ui.eccForm.setError(
+          'ECC Key cannot be empty. Use [Wipe] to clear a key.');
     }
 
-    function initSlotConfigForm() {
-        var configBtns = Array.from(ui.slotConfigBtns.getElementsByTagName('input'));
-        configBtns.forEach(function (btn, i) {
-            var labelIndex = myOnlyKey.getSlotNum(btn.value);
-            var labelText = myOnlyKey.labels[labelIndex - 1] || 'empty';
-            onlyKeyConfigWizard.setSlotLabel(i, labelText);
-            btn.addEventListener('click', showSlotConfigForm);
-        });
-        ui.slotConfigDialog.getElementsByClassName('slot-config-close')[0].addEventListener('click', closeSlotConfigForm);
+    if (key.length !== maxKeyLength) {
+      return ui.eccForm.setError(
+          'ECC Key must be ' + maxKeyLength + ' characters.');
     }
 
-    function showSlotConfigForm(e) {
-        var slotId = e.target.value;
-        myOnlyKey.currentSlotId = slotId;
-        var slotLabel = document.getElementById('slotLabel' + slotId).innerText;
-        ui.slotConfigDialog.getElementsByClassName('slotId')[0].innerText = slotId;
+    // set all type modifiers
+    var typeModifier = 0;
 
-        document.getElementById('txtSlotLabel').value = slotLabel.toLowerCase() === 'empty' ? '' : slotLabel;
-        dialog.open(ui.slotConfigDialog);
-        initSlotConfigForm();
-        e && e.preventDefault && e.preventDefault();
+    Object.keys(myOnlyKey.keyTypeModifiers).forEach(function(modifier) {
+      if (ui.eccForm['eccSetAs' + modifier].checked) {
+        typeModifier += myOnlyKey.keyTypeModifiers[modifier];
+      }
+    });
+
+    type += typeModifier;
+
+    // TODO: validation
+    myOnlyKey.setPrivateKey(slot, type, key, function(err) {
+      // TODO: check for success, then reset
+      myOnlyKey.listen(handleMessage);
+      ui.eccForm.reset();
+    });
+
+    e && e.preventDefault && e.preventDefault();
+  }
+
+  function wipeEccKeyForm(e) {
+    ui.eccForm.setError('');
+
+    var slot = parseInt(ui.eccForm.eccSlot.value || '', 10);
+    myOnlyKey.wipePrivateKey(slot, function(err) {
+      myOnlyKey.listen(handleMessage);
+    });
+
+    e && e.preventDefault && e.preventDefault();
+  }
+
+  function submitRsaForm(e) {
+    e && e.preventDefault && e.preventDefault();
+    ui.rsaForm.setError('');
+
+    var key = ui.rsaForm.rsaKey.value || '';
+    var passcode = ui.rsaForm.rsaPasscode.value || '';
+
+    // key = key.toString().replace(/\s/g,'');
+
+    if (!key) {
+      return ui.rsaForm.setError(
+          'RSA Key cannot be empty. Use [Wipe] to clear a key.');
     }
 
-    function closeSlotConfigForm(e) {
-        dialog.close(ui.slotConfigDialog);
-        e && e.preventDefault && e.preventDefault();
+    if (!passcode) {
+      return ui.rsaForm.setError('Passcode cannot be empty.');
     }
 
-    function enableAuthForms() {
-        var yubiSubmit = document.getElementById('yubiSubmit');
-        var yubiWipe = document.getElementById('yubiWipe');
-        yubiSubmit.addEventListener('click', submitYubiAuthForm);
-        yubiWipe.addEventListener('click', wipeYubiAuthForm);
+    var privKey, keyObj = {}, retKey;
 
-        var u2fSubmit = document.getElementById('u2fSubmit');
-        var u2fWipe = document.getElementById('u2fWipe');
-        u2fSubmit.addEventListener('click', submitU2fAuthForm);
-        u2fWipe.addEventListener('click', wipeU2fAuthForm);
+    try {
+      var privKeys = openpgp.key.readArmored(key);
+      privKey = privKeys.keys[0];
 
-        var lockoutSubmit = document.getElementById('lockoutSubmit');
-        lockoutSubmit.addEventListener('click', submitLockoutForm);
+      var success = privKey.decrypt(passcode);
 
-        var wipeModeSubmit = document.getElementById('wipeModeSubmit');
-        wipeModeSubmit.addEventListener('click', submitWipeModeForm);
+      if (!success) {
+        throw new Error(
+            'Private Key decryption failed. Did you forget your passcode?');
+      }
 
-        var typeSpeedSubmit = document.getElementById('typeSpeedSubmit');
-        typeSpeedSubmit.addEventListener('click', submitTypeSpeedForm);
-
-        var kbdLayoutSubmit = document.getElementById('kbdLayoutSubmit');
-        kbdLayoutSubmit.addEventListener('click', submitKBDLayoutForm);
-
-        var eccSubmit = document.getElementById('eccSubmit');
-        eccSubmit.addEventListener('click', submitEccForm);
-        ui.eccForm.setError = function(errString) {
-            document.getElementById('eccFormError').innerText = errString;
-        };
-
-        var eccWipe = document.getElementById('eccWipe');
-        eccWipe.addEventListener('click', wipeEccKeyForm);
-
-        var rsaSubmit = document.getElementById('rsaSubmit');
-        rsaSubmit.addEventListener('click', submitRsaForm);
-        ui.rsaForm.setError = function (errString) {
-            document.getElementById('rsaFormError').innerText = errString;
-        };
-
-        var rsaWipe = document.getElementById('rsaWipe');
-        rsaWipe.addEventListener('click', wipeRsaKeyForm);
-
-        var backupSave = document.getElementById('backupSave');
-        backupSave.addEventListener('click', saveBackupFile);
-        ui.backupForm.setError = function (errString) {
-            document.getElementById('backupFormError').innerText = errString;
-        };
-
-        var restoreFromBackup = document.getElementById('doRestore');
-        restoreFromBackup.addEventListener('click', submitRestoreForm);
-        ui.restoreForm.setError = function (errString) {
-            document.getElementById('restoreFormError').innerText = errString;
-        };
-
-        ui.backupForm.setError('');
-        ui.backupForm.reset();
-        ui.restoreForm.setError('');
-        ui.restoreForm.reset();
+      if (!(privKey.primaryKey && privKey.primaryKey.mpi &&
+            privKey.primaryKey.mpi.length === 6)) {
+        throw new Error(
+            'Private Key decryption was successful, but resulted in invalid mpi data.');
+      }
+    } catch (e) {
+      return ui.rsaForm.setError('Error parsing RSA key: ' + e);
     }
 
-    function submitYubiAuthForm(e) {
-        var publicId = ui.yubiAuthForm.yubiPublicId.value || '';
-        var privateId = ui.yubiAuthForm.yubiPrivateId.value || '';
-        var secretKey = ui.yubiAuthForm.yubiSecretKey.value || '';
+    var allKeys = {primaryKey: privKey.primaryKey, subKeys: privKey.subKeys};
 
-        publicId = publicId.toString().replace(/\s/g,'');
-        privateId = privateId.toString().replace(/\s/g,'');
-        secretKey = secretKey.toString().replace(/\s/g,'');
+    onlyKeyConfigWizard.initKeySelect(allKeys, function(err) {
+      ui.rsaForm.setError(err);
+    });
+  }
 
-        // going to be mean and only send the max chars allowed
-        var maxPublicIdLength = 12; // 6 bytes
-        var maxPrivateIdLength = 12; // 6 bytes
-        var maxSecretKeyLength = 32; // 64 bytes
-        publicId = hexToModhex(publicId.slice(0, maxPublicIdLength), true);
-        privateId = privateId.slice(0, maxPrivateIdLength);
-        secretKey = secretKey.slice(0, maxSecretKeyLength);
+  OnlyKey.prototype.confirmRsaKeySelect = function(keyObj) {
+    var type = parseInt(keyObj.p.length / 64, 10);
 
-        // TODO: validation
-        myOnlyKey.setYubiAuth(publicId, privateId, secretKey, function (err) {
-            // TODO: check for success, then reset
-            ui.yubiAuthForm.reset();
-        });
-
-        e && e.preventDefault && e.preventDefault();
+    if ([1, 2, 3, 4].indexOf(type) < 0) {
+      return ui.rsaForm.setError(
+          'Selected key length should be 1024, 2048, 3072, or 4096 bits.');
     }
 
-    function wipeYubiAuthForm(e) {
-        myOnlyKey.wipeYubiAuth();
-        e && e.preventDefault && e.preventDefault();
+    var retKey = keyObj.p.concat(keyObj.q);
+    var slot = parseInt(ui.rsaForm.rsaSlot.value || '', 10);
+
+    // set all type modifiers
+    var typeModifier = 0;
+
+    Object.keys(myOnlyKey.keyTypeModifiers).forEach(function(modifier) {
+      if (ui.rsaForm['rsaSetAs' + modifier].checked) {
+        typeModifier += myOnlyKey.keyTypeModifiers[modifier];
+      }
+    });
+
+    type += typeModifier;
+
+    // console.info("retKey:", retKey);
+
+    submitRsaKey(slot, type, retKey, function(err) {
+      // TODO: check for success, then reset
+      myOnlyKey.listen(handleMessage);
+      ui.rsaForm.reset();
+    });
+
+  };
+
+  function submitRsaKey(slot, type, key, callback) {
+    // this function should recursively call itself until all bytes are sent in
+    // chunks
+    if (!Array.isArray(key)) {
+      return callback('Invalid key format.');
     }
+    var maxPacketSize = 57;
+    var finalPacket = key.length - maxPacketSize <= 0;
 
-    function submitU2fAuthForm(e) {
-        var privateId = ui.u2fAuthForm.u2fPrivateId.value || '';
-        var cert = ui.u2fAuthForm.u2fCert.value || '';
+    var cb = finalPacket ?
+        callback :
+        submitRsaKey.bind(null, slot, type, key.slice(maxPacketSize), callback);
 
-        privateId = privateId.toString().replace(/\s/g,'');
-        cert = cert.toString().replace(/\s/g,'');
+    myOnlyKey.setPrivateKey(slot, type, key.slice(0, maxPacketSize), cb);
+  }
 
-        // going to be mean and only send the max chars allowed
-        var maxPrivateIdLength = 64; // 32 bytes
-        var maxCertLength = 2048; // 1024 bytes
-        privateId = privateId.slice(0, maxPrivateIdLength);
-        cert = cert.slice(0, maxCertLength);
+  function saveBackupFile(e) {
+    e && e.preventDefault && e.preventDefault();
+    ui.backupForm.setError('');
 
-        // TODO: validation
-        myOnlyKey.setU2fPrivateId(privateId, function (err) {
-            submitU2fCert(cert, function (err) {
-                // TODO: check for success, then reset
-                ui.u2fAuthForm.reset();
+    var backupData = ui.backupForm.backupData.value.trim();
+    if (backupData) {
+      var filename = 'onlykey-backup-' + (new Date().getTime()) + '.txt';
+      var blob = new Blob([backupData], {type: 'text/plain;charset=utf-8'});
+      saveAs(blob, filename);  // REQUIRES FileSaver.js polyfill
+
+      document.getElementById('lastBackupFilename').innerText = filename;
+      ui.backupForm.reset();
+    } else {
+      ui.backupForm.setError('Backup data cannot be empty space.');
+    }
+  }
+
+  function submitRestoreForm(e) {
+    e && e.preventDefault && e.preventDefault();
+    ui.restoreForm.setError('');
+
+    var fileSelector = ui.restoreForm.restoreSelectFile;
+    if (fileSelector.files && fileSelector.files.length) {
+      var file = fileSelector.files[0];
+      var reader = new FileReader();
+
+      reader.onload = (function(theFile) {
+        return function(e) {
+          // console.info("RESULT:", e.target.result);
+          var contents = e.target && e.target.result && e.target.result.trim();
+          try {
+            contents = parseBackupData(contents);
+          } catch (parseError) {
+            return ui.restoreForm.setError(
+                'Could not parse backup file.\n\n' + parseError);
+          }
+
+          if (contents) {
+            ui.restoreForm.setError('Working...');
+            submitRestoreData(contents, function(err) {
+              // TODO: check for success, then reset
+              ui.restoreForm.reset();
+              ui.restoreForm.setError('Done!');
             });
-        });
-
-        e && e.preventDefault && e.preventDefault();
-    }
-
-    function submitU2fCert(certStr, callback) {
-        // this function should recursively call itself until all bytes are sent in chunks
-        if (!certStr.length) {
-            return callback();
-        }
-
-        var maxPacketSize = 116; // 58 byte pairs
-        var finalPacket = certStr.length - maxPacketSize <= 0;
-
-        var cb = finalPacket ? callback : submitU2fCert.bind(null, certStr.slice(maxPacketSize), callback);
-
-        // packetHeader is hex number of bytes in certStr chunk
-        var packetHeader = finalPacket ? (certStr.length / 2).toString(16) : "FF";
-
-        myOnlyKey.setU2fCert(certStr.slice(0, maxPacketSize), packetHeader, cb);
-    }
-
-    function wipeU2fAuthForm(e) {
-        myOnlyKey.wipeU2fPrivateId(function (err) {
-            myOnlyKey.wipeU2fCert();
-        });
-
-        e && e.preventDefault && e.preventDefault();
-    }
-
-    function submitEccForm(e) {
-        ui.eccForm.setError('');
-
-        var type = parseInt(ui.eccForm.eccType.value || '', 10);
-        var slot = parseInt(ui.eccForm.eccSlot.value || '', 10);
-        var key = ui.eccForm.eccKey.value || '';
-
-        var maxKeyLength = 64; // 32 hex pairs
-
-        key = key.toString().replace(/\s/g,'').slice(0, maxKeyLength);
-
-        if (!key) {
-            return ui.eccForm.setError('ECC Key cannot be empty. Use [Wipe] to clear a key.');
-        }
-
-        if (key.length !== maxKeyLength) {
-            return ui.eccForm.setError('ECC Key must be ' + maxKeyLength + ' characters.');
-        }
-
-        // set all type modifiers
-        var typeModifier = 0;
-
-        Object.keys(myOnlyKey.keyTypeModifiers).forEach(function (modifier) {
-            if (ui.eccForm['eccSetAs' + modifier].checked) {
-                typeModifier += myOnlyKey.keyTypeModifiers[modifier];
-            }
-        });
-
-        type += typeModifier;
-
-        // TODO: validation
-        myOnlyKey.setPrivateKey(slot, type, key, function (err) {
-            // TODO: check for success, then reset
-            myOnlyKey.listen(handleMessage);
-            ui.eccForm.reset();
-        });
-
-        e && e.preventDefault && e.preventDefault();
-    }
-
-    function wipeEccKeyForm(e) {
-        ui.eccForm.setError('');
-
-        var slot = parseInt(ui.eccForm.eccSlot.value || '', 10);
-        myOnlyKey.wipePrivateKey(slot, function (err) {
-            myOnlyKey.listen(handleMessage);
-        });
-
-        e && e.preventDefault && e.preventDefault();
-    }
-
-    function submitRsaForm(e) {
-        e && e.preventDefault && e.preventDefault();
-        ui.rsaForm.setError('');
-
-        var key = ui.rsaForm.rsaKey.value || '';
-        var passcode = ui.rsaForm.rsaPasscode.value || '';
-
-        //key = key.toString().replace(/\s/g,'');
-
-        if (!key) {
-            return ui.rsaForm.setError('RSA Key cannot be empty. Use [Wipe] to clear a key.');
-        }
-
-        if (!passcode) {
-            return ui.rsaForm.setError('Passcode cannot be empty.');
-        }
-
-        var privKey, keyObj = {}, retKey;
-
-        try {
-            var privKeys = openpgp.key.readArmored(key);
-            privKey = privKeys.keys[0];
-
-            var success = privKey.decrypt(passcode);
-
-            if (!success) {
-                throw new Error("Private Key decryption failed. Did you forget your passcode?");
-            }
-
-            if (!(privKey.primaryKey && privKey.primaryKey.mpi && privKey.primaryKey.mpi.length === 6)) {
-                throw new Error("Private Key decryption was successful, but resulted in invalid mpi data.");
-            }
-        } catch (e) {
-            return ui.rsaForm.setError('Error parsing RSA key: ' + e);
-        }
-
-        var allKeys = {
-            primaryKey: privKey.primaryKey,
-            subKeys: privKey.subKeys
+          } else {
+            return ui.restoreForm.setError('Incorrect backup data format.');
+          }
         };
+      })(file);
 
-        onlyKeyConfigWizard.initKeySelect(allKeys, function (err) {
-            ui.rsaForm.setError(err);
-        });
+      // Read in the image file as a data URL.
+      reader.readAsText(file);
+    } else {
+      ui.restoreForm.setError('Please select a file first.');
+    }
+  }
+
+  function submitRestoreData(restoreData, callback) {
+    // this function should recursively call itself until all bytes are sent in
+    // chunks
+    if (!restoreData.length) {
+      return callback();
     }
 
-    OnlyKey.prototype.confirmRsaKeySelect = function (keyObj) {
-        var type = parseInt(keyObj.p.length / 64, 10);
+    var maxPacketSize = 114;  // 57 byte pairs
+    var finalPacket = restoreData.length - maxPacketSize <= 0;
 
-        if ([1,2,3,4].indexOf(type) < 0) {
-            return ui.rsaForm.setError("Selected key length should be 1024, 2048, 3072, or 4096 bits.");
-        }
+    var cb = finalPacket ?
+        callback :
+        submitRestoreData.bind(
+            null, restoreData.slice(maxPacketSize), callback);
 
-        var retKey = keyObj.p.concat(keyObj.q);
-        var slot = parseInt(ui.rsaForm.rsaSlot.value || '', 10);
+    // packetHeader is hex number of bytes in certStr chunk
+    var packetHeader =
+        finalPacket ? (restoreData.length / 2).toString(16) : 'FF';
 
-        // set all type modifiers
-        var typeModifier = 0;
+    myOnlyKey.restore(restoreData.slice(0, maxPacketSize), packetHeader, cb);
+  }
 
-        Object.keys(myOnlyKey.keyTypeModifiers).forEach(function (modifier) {
-            if (ui.rsaForm['rsaSetAs' + modifier].checked) {
-                typeModifier += myOnlyKey.keyTypeModifiers[modifier];
-            }
-        });
+  function wipeRsaKeyForm(e) {
+    ui.rsaForm.setError('');
 
-        type += typeModifier;
+    var slot = parseInt(ui.rsaForm.rsaSlot.value || '', 10);
+    myOnlyKey.wipePrivateKey(slot, function(err) {
+      myOnlyKey.listen(handleMessage);
+    });
 
-        // console.info("retKey:", retKey);
+    e && e.preventDefault && e.preventDefault();
+  }
 
-        submitRsaKey(slot, type, retKey, function (err) {
-            // TODO: check for success, then reset
-            myOnlyKey.listen(handleMessage);
-            ui.rsaForm.reset();
-        });
-
-    };
-
-    function submitRsaKey(slot, type, key, callback) {
-        // this function should recursively call itself until all bytes are sent in chunks
-        if (!Array.isArray(key)) {
-            return callback('Invalid key format.');
-        }
-        var maxPacketSize = 57;
-        var finalPacket = key.length - maxPacketSize <= 0;
-
-        var cb = finalPacket ? callback : submitRsaKey.bind(null, slot, type, key.slice(maxPacketSize), callback);
-
-        myOnlyKey.setPrivateKey(slot, type, key.slice(0, maxPacketSize), cb);
+  function submitLockoutForm(e) {
+    var lockout = parseInt(ui.lockoutForm.okLockout.value, 10);
+    if (isNaN(lockout)) {
+      lockout = 0;
     }
 
-    function saveBackupFile(e) {
-        e && e.preventDefault && e.preventDefault();
-        ui.backupForm.setError('');
-
-        var backupData = ui.backupForm.backupData.value.trim();
-        if (backupData) {
-            var filename = "onlykey-backup-" + (new Date().getTime()) + ".txt";
-            var blob = new Blob([backupData], {type: "text/plain;charset=utf-8"});
-            saveAs(blob, filename); // REQUIRES FileSaver.js polyfill
-
-            document.getElementById('lastBackupFilename').innerText = filename;
-            ui.backupForm.reset();
-        } else {
-            ui.backupForm.setError('Backup data cannot be empty space.');
-        }
+    if (typeof lockout !== 'number' || lockout < 0) {
+      lockout = 30;
     }
 
-    function submitRestoreForm(e) {
-        e && e.preventDefault && e.preventDefault();
-        ui.restoreForm.setError('');
+    lockout = Math.min(lockout, 255);
 
-        var fileSelector = ui.restoreForm.restoreSelectFile;
-        if (fileSelector.files && fileSelector.files.length) {
-            var file = fileSelector.files[0];
-            var reader = new FileReader();
+    myOnlyKey.setLockout(lockout, function(err) {
+      myOnlyKey.setLastMessage(
+          'received',
+          'Lockout set to ' + lockout + ' minutes' +
+              (lockout === 0 ? ' (disabled)' : ''));
+      ui.lockoutForm.reset();
+    });
 
-            reader.onload = (function (theFile) {
-                return function (e) {
-                    //console.info("RESULT:", e.target.result);
-                    var contents = e.target && e.target.result && e.target.result.trim();
-                    try {
-                        contents = parseBackupData(contents);
-                    } catch(parseError) {
-                        return ui.restoreForm.setError('Could not parse backup file.\n\n' + parseError);
-                    }
+    e && e.preventDefault && e.preventDefault();
+  }
 
-                    if (contents) {
-                        ui.restoreForm.setError('Working...');
-                        submitRestoreData(contents, function (err) {
-                            // TODO: check for success, then reset
-                            ui.restoreForm.reset();
-                            ui.restoreForm.setError('Done!');
-                        });
-                    } else {
-                        return ui.restoreForm.setError('Incorrect backup data format.');
-                    }
-                };
-            })(file);
+  function submitWipeModeForm(e) {
+    var wipeMode = parseInt(ui.wipeModeForm.okWipeMode.value, 10);
 
-            // Read in the image file as a data URL.
-            reader.readAsText(file);
-        } else {
-            ui.restoreForm.setError('Please select a file first.');
-        }
+    myOnlyKey.setWipeMode(wipeMode, function(err) {
+      myOnlyKey.setLastMessage('received', 'Wipe Mode set successfully');
+      ui.wipeModeForm.reset();
+    });
+
+    e && e.preventDefault && e.preventDefault();
+  }
+
+  function submitTypeSpeedForm(e) {
+    var typeSpeed = parseInt(ui.typeSpeedForm.okTypeSpeed.value, 10);
+
+    if (typeof typeSpeed !== 'number' || typeSpeed < 1) {
+      typeSpeed = 1;
     }
 
-    function submitRestoreData(restoreData, callback) {
-        // this function should recursively call itself until all bytes are sent in chunks
-        if (!restoreData.length) {
-            return callback();
-        }
+    typeSpeed = Math.min(typeSpeed, 10);
 
-        var maxPacketSize = 114; // 57 byte pairs
-        var finalPacket = restoreData.length - maxPacketSize <= 0;
+    myOnlyKey.setTypeSpeed(typeSpeed, function(err) {
+      myOnlyKey.setLastMessage('received', 'Type Speed mode set successfully');
+      ui.typeSpeedForm.reset();
+    });
 
-        var cb = finalPacket ? callback : submitRestoreData.bind(null, restoreData.slice(maxPacketSize), callback);
+    e && e.preventDefault && e.preventDefault();
+  }
 
-        // packetHeader is hex number of bytes in certStr chunk
-        var packetHeader = finalPacket ? (restoreData.length / 2).toString(16) : "FF";
+  function submitKBDLayoutForm(e) {
+    var kbdLayout = parseInt(ui.keyboardLayoutForm.okKeyboardLayout.value, 10);
 
-        myOnlyKey.restore(restoreData.slice(0, maxPacketSize), packetHeader, cb);        
+    if (typeof kbdLayout !== 'number' || kbdLayout < 1) {
+      kbdLayout = 1;
     }
 
-    function wipeRsaKeyForm(e) {
-        ui.rsaForm.setError('');
+    kbdLayout = Math.min(kbdLayout, 25);
 
-        var slot = parseInt(ui.rsaForm.rsaSlot.value || '', 10);
-        myOnlyKey.wipePrivateKey(slot, function (err) {
-            myOnlyKey.listen(handleMessage);
-        });
+    myOnlyKey.setKBDLayout(kbdLayout, function(err) {
+      myOnlyKey.setLastMessage('received', 'Keyboard Layout set successfully');
+      ui.keyboardLayoutForm.reset();
+    });
 
-        e && e.preventDefault && e.preventDefault();
+    e && e.preventDefault && e.preventDefault();
+  }
+
+  function setOkVersionStr() {
+    var version = myOnlyKey.getVersion();
+    if (version) {
+      document.getElementById('okVersionStr').innerText =
+          'OnlyKey firmware ' + version;
     }
+  }
 
-    function submitLockoutForm(e) {
-        var lockout = parseInt(ui.lockoutForm.okLockout.value, 10);
-		if (isNaN(lockout)) {
-			lockout = 0;
-		}
-
-		if (typeof lockout !== 'number' || lockout < 0) {
-            lockout = 30;
-        }
-
-        lockout = Math.min(lockout, 255);
-
-        myOnlyKey.setLockout(lockout, function (err) {
-			myOnlyKey.setLastMessage('received', 'Lockout set to ' + lockout + ' minutes' + (lockout === 0 ? ' (disabled)' : ''));
-            ui.lockoutForm.reset();
-        });
-
-        e && e.preventDefault && e.preventDefault();
-    }
-
-    function submitWipeModeForm(e) {
-        var wipeMode = parseInt(ui.wipeModeForm.okWipeMode.value, 10);
-
-        myOnlyKey.setWipeMode(wipeMode, function (err) {
-            myOnlyKey.setLastMessage('received', 'Wipe Mode set successfully');
-            ui.wipeModeForm.reset();
-        });
-
-        e && e.preventDefault && e.preventDefault();
-    }
-
-    function submitTypeSpeedForm(e) {
-        var typeSpeed = parseInt(ui.typeSpeedForm.okTypeSpeed.value, 10);
-
-        if (typeof typeSpeed !== 'number' || typeSpeed < 1) {
-            typeSpeed = 1;
-        }
-
-        typeSpeed = Math.min(typeSpeed, 10);
-
-         myOnlyKey.setTypeSpeed(typeSpeed, function (err) {
-            myOnlyKey.setLastMessage('received', 'Type Speed mode set successfully');
-            ui.typeSpeedForm.reset();
-        });
-
-        e && e.preventDefault && e.preventDefault();
-    }
-
-    function submitKBDLayoutForm(e) {
-        var kbdLayout = parseInt(ui.keyboardLayoutForm.okKeyboardLayout.value, 10);
-
-        if (typeof kbdLayout !== 'number' || kbdLayout < 1) {
-            kbdLayout = 1;
-        }
-
-        kbdLayout = Math.min(kbdLayout, 25);
-
-        myOnlyKey.setKBDLayout(kbdLayout, function (err) {
-            myOnlyKey.setLastMessage('received', 'Keyboard Layout set successfully');
-            ui.keyboardLayoutForm.reset();
-        });
-
-        e && e.preventDefault && e.preventDefault();
-    }
-
-	function setOkVersionStr() {
-		var version = myOnlyKey.getVersion();
-		if (version) {
-			document.getElementById("okVersionStr").innerText = "OnlyKey firmware " + version;
-		}
-	}
-
-    window.addEventListener('load', init);
+  window.addEventListener('load', init);
 };
 
 
 function hexToModhex(inputStr, reverse) {
-    // 0123 4567 89ab cdef
-    // cbde fghi jkln rtuv
-    // Example: hexadecimal number "4711" translates to "fibb"
-    var hex     = '0123456789abcdef';
-    var modhex  = 'cbdefghijklnrtuv';
-    var newStr  = '';
-    var o = reverse ? modhex : hex;
-    var t = reverse ? hex : modhex;
-    inputStr.split('').forEach(function (c) {
-        var i = o.indexOf(c);
-        if (i < 0) {
-            throw new Error('Invalid character sent for hexToModhex conversion');
-        }
-        newStr += t.charAt(i);
-    });
+  // 0123 4567 89ab cdef
+  // cbde fghi jkln rtuv
+  // Example: hexadecimal number "4711" translates to "fibb"
+  var hex = '0123456789abcdef';
+  var modhex = 'cbdefghijklnrtuv';
+  var newStr = '';
+  var o = reverse ? modhex : hex;
+  var t = reverse ? hex : modhex;
+  inputStr.split('').forEach(function(c) {
+    var i = o.indexOf(c);
+    if (i < 0) {
+      throw new Error('Invalid character sent for hexToModhex conversion');
+    }
+    newStr += t.charAt(i);
+  });
 
-    return newStr;
+  return newStr;
 }
 
 function strPad(str, places, char) {
-    while (str.length < places) {
-        str = "" + (char || 0) + str;
-    }
+  while (str.length < places) {
+    str = '' + (char || 0) + str;
+  }
 
-    return str;
+  return str;
 }
 
 // we owe russ a beer
 // http://blog.tinisles.com/2011/10/google-authenticator-one-time-password-algorithm-in-javascript/
 function base32tohex(base32) {
-    var base32chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
-    var bits = "";
-    var hex = "";
+  var base32chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+  var bits = '';
+  var hex = '';
 
-    for (var i = 0; i < base32.length; i++) {
-        var val = base32chars.indexOf(base32.charAt(i).toUpperCase());
-        bits += strPad(val.toString(2), 5, '0');
-    }
+  for (var i = 0; i < base32.length; i++) {
+    var val = base32chars.indexOf(base32.charAt(i).toUpperCase());
+    bits += strPad(val.toString(2), 5, '0');
+  }
 
-    for (var i = 0; i+4 <= bits.length; i+=4) {
-        var chunk = bits.substr(i, 4);
-        hex = hex + parseInt(chunk, 2).toString(16) ;
-    }
-    return hex;
+  for (var i = 0; i + 4 <= bits.length; i += 4) {
+    var chunk = bits.substr(i, 4);
+    hex = hex + parseInt(chunk, 2).toString(16);
+  }
+  return hex;
 }
 
 // http://stackoverflow.com/questions/39460182/decode-base64-to-hexadecimal-string-with-javascript
 function base64tohex(base64) {
-    var raw = atob(base64);
-    var HEX = '';
-    var _hex;
+  var raw = atob(base64);
+  var HEX = '';
+  var _hex;
 
-    for (i = 0; i < raw.length; i++) {
-        _hex = raw.charCodeAt(i).toString(16);
-        HEX += (_hex.length == 2 ? _hex : '0' + _hex);
-    }
-    return HEX.toUpperCase();
+  for (i = 0; i < raw.length; i++) {
+    _hex = raw.charCodeAt(i).toString(16);
+    HEX += (_hex.length == 2 ? _hex : '0' + _hex);
+  }
+  return HEX.toUpperCase();
 }
 
 function parseBackupData(contents) {
-    var newContents = [];
-    // split by newline
-    contents.split('\n').forEach(function (line) {
-        if (line.indexOf('--') !== 0) {
-            newContents.push(base64tohex(line));
-        }
-    });
+  var newContents = [];
+  // split by newline
+  contents.split('\n').forEach(function(line) {
+    if (line.indexOf('--') !== 0) {
+      newContents.push(base64tohex(line));
+    }
+  });
 
-    // join back to unified base64 string
-    newContents = newContents.join('');
-    return newContents;
+  // join back to unified base64 string
+  newContents = newContents.join('');
+  return newContents;
 }
 
 function hexStrToDec(hexStr) {
-    return new Number('0x' + hexStr).toString(10);
+  return new Number('0x' + hexStr).toString(10);
 }
 
 function byteToHex(value) {
-    if (value < 16) return '0' + value.toString(16);
-    return value.toString(16);
+  if (value < 16) return '0' + value.toString(16);
+  return value.toString(16);
 }

--- a/app/scripts/onlyKey/OnlyKeyWizard.js
+++ b/app/scripts/onlyKey/OnlyKeyWizard.js
@@ -1,525 +1,472 @@
-(function () {
-    var onlyKeyConfigWizard;
-    var dialog = new dialogMgr();
+(function() {
+var onlyKeyConfigWizard;
+var dialog = new dialogMgr();
 
-    var steps = {
-        Step1: {
-            next: 'Step2'
-        },
-        Step2: {
-            prev: 'Step1',
-            next: 'Step3'
-        },
-        Step3: {
-            prev: 'Step2',
-            next: 'Step4'
-        },
-        Step4: {
-            prev: 'Step3',
-            next: 'Step5'
-        },
-        Step5: {
-            prev: 'Step4',
-            next: 'Step6'
-        },
-        Step6: {
-            prev: 'Step5',
-            next: 'Step7'
-        },
-        Step7: {
-            prev: 'Step6',
-            next: 'Step8'
-        },
-        Step8: {
-            prev: 'Step7',
-            next: 'Step9'
-        },
-        Step9: {
-            prev: 'Step8'
-        }
-    };
+var steps = {
+  Step1: {next: 'Step2'},
+  Step2: {prev: 'Step1', next: 'Step3'},
+  Step3: {prev: 'Step2', next: 'Step4'},
+  Step4: {prev: 'Step3', next: 'Step5'},
+  Step5: {prev: 'Step4', next: 'Step6'},
+  Step6: {prev: 'Step5', next: 'Step7'},
+  Step7: {prev: 'Step6', next: 'Step8'},
+  Step8: {prev: 'Step7', next: 'Step9'},
+  Step9: {prev: 'Step8'}
+};
 
-    function Wizard() {
-        this.steps = steps;
-        this.currentSlot = {};
-    }
+function Wizard() {
+  this.steps = steps;
+  this.currentSlot = {};
+}
 
-    Wizard.prototype.init = function (myOnlyKey) {
-        var self = this;
-        self.onlyKey = myOnlyKey;
-        self.currentStep = Object.keys(self.steps)[0];
-        self.uiInit();
+Wizard.prototype.init = function(myOnlyKey) {
+  var self = this;
+  self.onlyKey = myOnlyKey;
+  self.currentStep = Object.keys(self.steps)[0];
+  self.uiInit();
 
-        self.steps.Step2.exitFn = function (cb) {
-            var dynamicSteps = Array.from(document.querySelectorAll('[data-step="Step7"],[data-step="Step8"]'));
-            var classListMethod = self.getMode() === 'TwoFactor' ? 'remove' : 'add';
+  self.steps.Step2.exitFn = function(cb) {
+    var dynamicSteps = Array.from(
+        document.querySelectorAll('[data-step="Step7"],[data-step="Step8"]'));
+    var classListMethod = self.getMode() === 'TwoFactor' ? 'remove' : 'add';
 
-            dynamicSteps.forEach(function (el) {
-                el.classList[classListMethod]('hide');
-            });
+    dynamicSteps.forEach(function(el) {
+      el.classList[classListMethod]('hide');
+    });
 
-            return cb();
-        };
-        self.steps.Step3.enterFn = function () {
-            enableDisclaimer.call(self, 'passcode1Disclaimer');
-            myOnlyKey.sendSetPin.call(myOnlyKey);
-        };
-        self.steps.Step3.exitFn = myOnlyKey.sendSetPin.bind(myOnlyKey);
-        self.steps.Step4.enterFn = myOnlyKey.sendSetPin.bind(myOnlyKey);
-        self.steps.Step4.exitFn = myOnlyKey.sendSetPin.bind(myOnlyKey);
-        self.steps.Step5.enterFn = function () {
-            enableDisclaimer.call(self, 'passcode2Disclaimer');
-            myOnlyKey.sendSetSDPin.call(myOnlyKey);
-        };
-        self.steps.Step5.exitFn = myOnlyKey.sendSetSDPin.bind(myOnlyKey);
-        self.steps.Step6.enterFn = myOnlyKey.sendSetSDPin.bind(myOnlyKey);
-        self.steps.Step6.exitFn = function (cb) {
-            myOnlyKey.sendSetSDPin.call(myOnlyKey, function (err, res) {
-                if (err || self.getMode() === 'TwoFactor') {
-                    return cb(err, res);
-                }
+    return cb();
+  };
+  self.steps.Step3.enterFn = function() {
+    enableDisclaimer.call(self, 'passcode1Disclaimer');
+    myOnlyKey.sendSetPin.call(myOnlyKey);
+  };
+  self.steps.Step3.exitFn = myOnlyKey.sendSetPin.bind(myOnlyKey);
+  self.steps.Step4.enterFn = myOnlyKey.sendSetPin.bind(myOnlyKey);
+  self.steps.Step4.exitFn = myOnlyKey.sendSetPin.bind(myOnlyKey);
+  self.steps.Step5.enterFn = function() {
+    enableDisclaimer.call(self, 'passcode2Disclaimer');
+    myOnlyKey.sendSetSDPin.call(myOnlyKey);
+  };
+  self.steps.Step5.exitFn = myOnlyKey.sendSetSDPin.bind(myOnlyKey);
+  self.steps.Step6.enterFn = myOnlyKey.sendSetSDPin.bind(myOnlyKey);
+  self.steps.Step6.exitFn = function(cb) {
+    myOnlyKey.sendSetSDPin.call(myOnlyKey, function(err, res) {
+      if (err || self.getMode() === 'TwoFactor') {
+        return cb(err, res);
+      }
 
-                dialog.open.call(null, self.finalStepDialog);
-                return cb(null, 'STOP');
-            });
-        };
-        self.steps.Step7.enterFn = function () {
-            enableDisclaimer.call(self, 'passcode3Disclaimer');
-            myOnlyKey.sendSetPDPin.call(myOnlyKey);
-        };
-        self.steps.Step7.exitFn = myOnlyKey.sendSetPDPin.bind(myOnlyKey);
-        self.steps.Step8.enterFn = myOnlyKey.sendSetPDPin.bind(myOnlyKey);
-        self.steps.Step8.exitFn = myOnlyKey.sendSetPDPin.bind(myOnlyKey);
-        self.steps.Step9.enterFn = dialog.open.bind(null, self.finalStepDialog);
+      dialog.open.call(null, self.finalStepDialog);
+      return cb(null, 'STOP');
+    });
+  };
+  self.steps.Step7.enterFn = function() {
+    enableDisclaimer.call(self, 'passcode3Disclaimer');
+    myOnlyKey.sendSetPDPin.call(myOnlyKey);
+  };
+  self.steps.Step7.exitFn = myOnlyKey.sendSetPDPin.bind(myOnlyKey);
+  self.steps.Step8.enterFn = myOnlyKey.sendSetPDPin.bind(myOnlyKey);
+  self.steps.Step8.exitFn = myOnlyKey.sendSetPDPin.bind(myOnlyKey);
+  self.steps.Step9.enterFn = dialog.open.bind(null, self.finalStepDialog);
 
-    };
+};
 
-    function enableDisclaimer(fieldName) {
-        var self = this;
-        var field = self.initForm[fieldName];
-        field.removeEventListener('change', enableDisclaimer);
-        self.btnNext.disabled = !field.checked;
-        field.addEventListener('change', function (e) {
-            enableDisclaimer.call(self, fieldName);
-        });
-    }
+function enableDisclaimer(fieldName) {
+  var self = this;
+  var field = self.initForm[fieldName];
+  field.removeEventListener('change', enableDisclaimer);
+  self.btnNext.disabled = !field.checked;
+  field.addEventListener('change', function(e) {
+    enableDisclaimer.call(self, fieldName);
+  });
+}
 
-    Wizard.prototype.uiInit = function () {
-        var self = this;
+Wizard.prototype.uiInit = function() {
+  var self = this;
 
-        self.initForm = document['init-panel'];
+  self.initForm = document['init-panel'];
 
-        self.btnNext = document.getElementById('ButtonNext');
-        self.btnPrev = document.getElementById('ButtonPrevious');
+  self.btnNext = document.getElementById('ButtonNext');
+  self.btnPrev = document.getElementById('ButtonPrevious');
 
-        self.btnNext.onclick = moveStep.bind(this, 'next');
-        self.btnPrev.onclick = moveStep.bind(this, 'prev');
+  self.btnNext.onclick = moveStep.bind(this, 'next');
+  self.btnPrev.onclick = moveStep.bind(this, 'prev');
 
-        self.slotConfigForm = document['slot-config-form'];
-        self.slotConfigDialog = document.getElementById('slot-config-dialog');
+  self.slotConfigForm = document['slot-config-form'];
+  self.slotConfigDialog = document.getElementById('slot-config-dialog');
 
-        self.finalStepDialog = document.getElementById('finalStep-dialog');
+  self.finalStepDialog = document.getElementById('finalStep-dialog');
 
-        self.slotWipe = document.getElementById('slotWipe');
-        self.slotWipe.onclick = function (e) {
-            document.getElementById('wipeCurrentSlotId').innerText = self.onlyKey.currentSlotId;
-            dialog.open(self.slotWipeConfirmDialog, true);
-            e && e.preventDefault && e.preventDefault();
-        };
+  self.slotWipe = document.getElementById('slotWipe');
+  self.slotWipe.onclick = function(e) {
+    document.getElementById('wipeCurrentSlotId').innerText =
+        self.onlyKey.currentSlotId;
+    dialog.open(self.slotWipeConfirmDialog, true);
+    e && e.preventDefault && e.preventDefault();
+  };
 
-        self.slotWipeConfirmDialog = document.getElementById('slot-wipe-confirm');
-        self.slotWipeConfirmBtn = document.getElementById('slotWipeConfirm');
-        self.slotWipeConfirmBtn.onclick = function (e) {
-            self.onlyKey.wipeSlot(null, null, function (err, msg) {
-                // self.onlyKey.listen(function (err, msg) {
-                    if (!err) {
-                        self.slotConfigForm.reset();
-                        self.onlyKey.getLabels();
-                        dialog.closeAll();
-                    }
-                // });
-            });
-
-            e && e.preventDefault && e.preventDefault();
-        };
-
-        self.slotWipeCancelBtn = document.getElementById('slotWipeCancel');
-        self.slotWipeCancelBtn.onclick = function (e) {
-            dialog.close(self.slotWipeConfirmDialog);
-            e && e.preventDefault && e.preventDefault();
-        };
-
-        self.slotSubmit = document.getElementById('slotSubmit');
-        self.slotSubmit.onclick = function (e) {
-            setSlot.call(self);
-            e && e.preventDefault && e.preventDefault();
-        };
-
-        // BEGIN PRIVATE KEY SELECTOR
-        self.selectPrivateKeyDialog = document.getElementById('select-private-key-dialog');
-        self.selectPrivateKeyConfirmBtn = document.getElementById('selectPrivateKeyConfirm');
-        self.selectPrivateKeyConfirmBtn.onclick = function (e) {
-            e && e.preventDefault && e.preventDefault();
-            var selectedKey = document.querySelector('input[name="rsaKeySelect"]:checked').value;
-            self.onlyKey.confirmRsaKeySelect(self.onlyKey.tempRsaKeys[selectedKey]);
-            self.onlyKey.tempRsaKeys = null;
-            dialog.closeAll();
-        };
-
-        self.selectPrivateKeyCancelBtn = document.getElementById('selectPrivateKeyCancel');
-        self.selectPrivateKeyCancelBtn.onclick = function (e) {
-            e && e.preventDefault && e.preventDefault();
-            self.onlyKey.tempRsaKeys = null;
-            dialog.closeAll();
-        };
-        // END PRIVATE KEY SELECTOR
-
-        setActiveStepUI.call(this);
-    };
-
-    Wizard.prototype.initKeySelect = function (rawKey, cb) {
-        var self = this;
-
-        if (! rawKey.primaryKey || ! rawKey.subKeys) {
-            return cb('Cannot initialize key select form due to invalid keys object.');
-        }
-
-        var keys = [{
-            name: 'Primary Key',
-            p: rawKey.primaryKey.mpi[3].data.toByteArray(),
-            q: rawKey.primaryKey.mpi[4].data.toByteArray()
-        }];
-
-        rawKey.subKeys.forEach(function (subKey, i) {
-            keys.push({
-                name: 'Subkey ' + (i + 1),
-                p: subKey.subKey.mpi[3].data.toByteArray(),
-                q: subKey.subKey.mpi[4].data.toByteArray()
-            });
-        });
-
-        self.onlyKey.tempRsaKeys = keys;
-
-        var pkDiv = document.getElementById('private-key-options');
-        pkDiv.innerHTML = "";
-
-        keys.forEach(function (key, i) {
-            pkDiv.appendChild(makeRadioButton('rsaKeySelect', i, key.name));
-            pkDiv.appendChild(document.createElement("br"));
-        });
-
-        pkDiv.appendChild(document.createElement("br"));
-
-        dialog.open(self.selectPrivateKeyDialog, true);
-    };
-
-    function setSlot() {
-        var self = this; // wizard
-
-        self.slotSubmit.disabled = true;
-        self.slotWipe.disabled = true;
-
-        var form = self.slotConfigForm;
-        var formErrors = [];
-        var formErrorsContainer = document.getElementById('slotConfigErrors');
-        var fieldMap = {
-            chkSlotLabel: {
-                input: form.txtSlotLabel,
-                msgId: 'LABEL'
-            },
-            chkSlotUrl: {
-                input: form.txtSlotUrl,
-                msgId: 'URL'
-            },
-            tabReturn1: {
-                input: form.tabReturn1,
-                msgId: 'NEXTKEY1'
-            },
-            chkDelay1: {
-                input: form.numDelay1,
-                msgId: 'DELAY1'
-            },
-            chkUserName: {
-                input: form.txtUserName,
-                msgId: 'USERNAME'
-            },
-            tabReturn2: {
-                input: form.tabReturn2,
-                msgId: 'NEXTKEY2'
-            },
-            chkDelay2: {
-                input: form.numDelay2,
-                msgId: 'DELAY2'
-            },
-            chkPassword: {
-                input: form.txtPassword,
-                msgId: 'PASSWORD'
-            },
-            tabReturn3: {
-                input: form.tabReturn3,
-                msgId: 'NEXTKEY3'
-            },
-            chkDelay3: {
-                input: form.numDelay3,
-                msgId: 'DELAY3'
-            },
-            mode: {
-                input: form.mode,
-                msgId: 'TFATYPE'
-            },
-            txt2FAUserName: {
-                input: form.txt2FAUserName,
-                msgId: 'TFAUSERNAME'
-            }
-        };
-
-        formErrorsContainer.innerHTML = "";
-
-        if (form.txtPassword.value !== form.txtPasswordConfirm.value) {
-            formErrors.push('Password fields do not match');
-        }
-
-        if (formErrors.length) {
-            // early exit
-            var html = "<ul>";
-            for (var i = 0; i < formErrors.length; i++) {
-                html += "<li><blink>" + formErrors[i]; + "</blink></li>";
-            }
-            formErrorsContainer.innerHTML = html + "</ul>";
-
-            self.slotSubmit.disabled = false;
-            self.slotWipe.disabled = false;
-            return;
-        }
-
-        // process all form fields
-        for (var field in fieldMap) {
-            var isChecked = false;
-            var formValue = null;
-            switch(form[field].type) {
-                case 'checkbox':
-                    if (form[field].checked) {
-                        isChecked = true;
-                        formValue = ('' + (fieldMap[field].input).value).trim();
-                        form[field].checked = false;
-                    }
-                    break;
-                case 'hidden':
-                case 'number':
-                case 'text':
-                    var checkVar = ('' + (form[field].value)).trim();
-                    if (checkVar.length) {
-                        isChecked = true;
-                        formValue = ('' + (fieldMap[field].input).value).trim();
-                        form[field].value = '';
-                    }
-                    break;
-                case undefined: // radios?
-                    if (form[field].value !== '') {
-                        isChecked = true;
-                        formValue = (fieldMap[field].input).value;
-                        clearRadios(field);
-                    }
-                    break;
-                default:
-                    break;
-            }
-            if (isChecked) {
-                self.currentSlot[field] = formValue;
-                switch(field) {
-                    case 'txt2FAUserName':
-                        if (self.currentSlot.mode === 'googleAuthOtp') {
-                            console.info("BASE32 value:", formValue);
-                            formValue = base32tohex(formValue.replace(/\s/g, ''));
-                            formValue = formValue.match(/.{2}/g);
-                            console.info("was converted to HEX:", formValue);
-                        }
-                        break;
-                }
-
-                self.onlyKey.setSlot(null, fieldMap[field].msgId, formValue, function (err, msg) {
-                    if (!err) {
-                        setSlot.call(self);
-                    }
-                });
-                return;
-            }
-        }
-
-        form.reset();
-        self.currentSlot = {};
-        self.slotSubmit.disabled = false;
-        self.slotWipe.disabled = false;
+  self.slotWipeConfirmDialog = document.getElementById('slot-wipe-confirm');
+  self.slotWipeConfirmBtn = document.getElementById('slotWipeConfirm');
+  self.slotWipeConfirmBtn.onclick = function(e) {
+    self.onlyKey.wipeSlot(null, null, function(err, msg) {
+      // self.onlyKey.listen(function (err, msg) {
+      if (!err) {
+        self.slotConfigForm.reset();
         self.onlyKey.getLabels();
-        dialog.close(self.slotConfigDialog);
+        dialog.closeAll();
+      }
+      // });
+    });
+
+    e && e.preventDefault && e.preventDefault();
+  };
+
+  self.slotWipeCancelBtn = document.getElementById('slotWipeCancel');
+  self.slotWipeCancelBtn.onclick = function(e) {
+    dialog.close(self.slotWipeConfirmDialog);
+    e && e.preventDefault && e.preventDefault();
+  };
+
+  self.slotSubmit = document.getElementById('slotSubmit');
+  self.slotSubmit.onclick = function(e) {
+    setSlot.call(self);
+    e && e.preventDefault && e.preventDefault();
+  };
+
+  // BEGIN PRIVATE KEY SELECTOR
+  self.selectPrivateKeyDialog =
+      document.getElementById('select-private-key-dialog');
+  self.selectPrivateKeyConfirmBtn =
+      document.getElementById('selectPrivateKeyConfirm');
+  self.selectPrivateKeyConfirmBtn.onclick = function(e) {
+    e && e.preventDefault && e.preventDefault();
+    var selectedKey =
+        document.querySelector('input[name="rsaKeySelect"]:checked').value;
+    self.onlyKey.confirmRsaKeySelect(self.onlyKey.tempRsaKeys[selectedKey]);
+    self.onlyKey.tempRsaKeys = null;
+    dialog.closeAll();
+  };
+
+  self.selectPrivateKeyCancelBtn =
+      document.getElementById('selectPrivateKeyCancel');
+  self.selectPrivateKeyCancelBtn.onclick = function(e) {
+    e && e.preventDefault && e.preventDefault();
+    self.onlyKey.tempRsaKeys = null;
+    dialog.closeAll();
+  };
+  // END PRIVATE KEY SELECTOR
+
+  setActiveStepUI.call(this);
+};
+
+Wizard.prototype.initKeySelect = function(rawKey, cb) {
+  var self = this;
+
+  if (!rawKey.primaryKey || !rawKey.subKeys) {
+    return cb('Cannot initialize key select form due to invalid keys object.');
+  }
+
+  var keys = [{
+    name: 'Primary Key',
+    p: rawKey.primaryKey.mpi[3].data.toByteArray(),
+    q: rawKey.primaryKey.mpi[4].data.toByteArray()
+  }];
+
+  rawKey.subKeys.forEach(function(subKey, i) {
+    keys.push({
+      name: 'Subkey ' + (i + 1),
+      p: subKey.subKey.mpi[3].data.toByteArray(),
+      q: subKey.subKey.mpi[4].data.toByteArray()
+    });
+  });
+
+  self.onlyKey.tempRsaKeys = keys;
+
+  var pkDiv = document.getElementById('private-key-options');
+  pkDiv.innerHTML = '';
+
+  keys.forEach(function(key, i) {
+    pkDiv.appendChild(makeRadioButton('rsaKeySelect', i, key.name));
+    pkDiv.appendChild(document.createElement('br'));
+  });
+
+  pkDiv.appendChild(document.createElement('br'));
+
+  dialog.open(self.selectPrivateKeyDialog, true);
+};
+
+function setSlot() {
+  var self = this;  // wizard
+
+  self.slotSubmit.disabled = true;
+  self.slotWipe.disabled = true;
+
+  var form = self.slotConfigForm;
+  var formErrors = [];
+  var formErrorsContainer = document.getElementById('slotConfigErrors');
+  var fieldMap = {
+    chkSlotLabel: {input: form.txtSlotLabel, msgId: 'LABEL'},
+    chkSlotUrl: {input: form.txtSlotUrl, msgId: 'URL'},
+    tabReturn1: {input: form.tabReturn1, msgId: 'NEXTKEY1'},
+    chkDelay1: {input: form.numDelay1, msgId: 'DELAY1'},
+    chkUserName: {input: form.txtUserName, msgId: 'USERNAME'},
+    tabReturn2: {input: form.tabReturn2, msgId: 'NEXTKEY2'},
+    chkDelay2: {input: form.numDelay2, msgId: 'DELAY2'},
+    chkPassword: {input: form.txtPassword, msgId: 'PASSWORD'},
+    tabReturn3: {input: form.tabReturn3, msgId: 'NEXTKEY3'},
+    chkDelay3: {input: form.numDelay3, msgId: 'DELAY3'},
+    mode: {input: form.mode, msgId: 'TFATYPE'},
+    txt2FAUserName: {input: form.txt2FAUserName, msgId: 'TFAUSERNAME'}
+  };
+
+  formErrorsContainer.innerHTML = '';
+
+  if (form.txtPassword.value !== form.txtPasswordConfirm.value) {
+    formErrors.push('Password fields do not match');
+  }
+
+  if (formErrors.length) {
+    // early exit
+    var html = '<ul>';
+    for (var i = 0; i < formErrors.length; i++) {
+      html += '<li><blink>' + formErrors[i];
+      +'</blink></li>';
     }
+    formErrorsContainer.innerHTML = html + '</ul>';
 
-    Wizard.prototype.getMode = function () {
-        return this.initForm['ConfigMode'].value;
-    };
+    self.slotSubmit.disabled = false;
+    self.slotWipe.disabled = false;
+    return;
+  }
 
-    function moveStep(direction) {
-        // if a next/prev step exists, call current step-related exit function
-        // and set new current step
-        if (this.steps[this.currentStep][direction]) {
-            if (this.steps[this.currentStep].exitFn) {
-                this.steps[this.currentStep].exitFn(function (err, res) {
-                    if (err) {
-                        console.error(err);
-                        goBackOnError(err, res);
-                    } else if (res !== 'STOP') {
-                        setNewCurrentStep.call(this, this.steps[this.currentStep][direction]);
-                    }
-                }.bind(this));
-            } else {
-                setNewCurrentStep.call(this, this.steps[this.currentStep][direction]);
-            }
+  // process all form fields
+  for (var field in fieldMap) {
+    var isChecked = false;
+    var formValue = null;
+    switch (form[field].type) {
+      case 'checkbox':
+        if (form[field].checked) {
+          isChecked = true;
+          formValue = ('' + (fieldMap[field].input).value).trim();
+          form[field].checked = false;
         }
-
-        return false;
+        break;
+      case 'hidden':
+      case 'number':
+      case 'text':
+        var checkVar = ('' + (form[field].value)).trim();
+        if (checkVar.length) {
+          isChecked = true;
+          formValue = ('' + (fieldMap[field].input).value).trim();
+          form[field].value = '';
+        }
+        break;
+      case undefined:  // radios?
+        if (form[field].value !== '') {
+          isChecked = true;
+          formValue = (fieldMap[field].input).value;
+          clearRadios(field);
+        }
+        break;
+      default:
+        break;
     }
+    if (isChecked) {
+      self.currentSlot[field] = formValue;
+      switch (field) {
+        case 'txt2FAUserName':
+          if (self.currentSlot.mode === 'googleAuthOtp') {
+            console.info('BASE32 value:', formValue);
+            formValue = base32tohex(formValue.replace(/\s/g, ''));
+            formValue = formValue.match(/.{2}/g);
+            console.info('was converted to HEX:', formValue);
+          }
+          break;
+      }
 
-    function goBackOnError(err, lastMessageSent) {
-        console.info(err, lastMessageSent);
+      self.onlyKey.setSlot(
+          null, fieldMap[field].msgId, formValue, function(err, msg) {
+            if (!err) {
+              setSlot.call(self);
+            }
+          });
+      return;
+    }
+  }
+
+  form.reset();
+  self.currentSlot = {};
+  self.slotSubmit.disabled = false;
+  self.slotWipe.disabled = false;
+  self.onlyKey.getLabels();
+  dialog.close(self.slotConfigDialog);
+}
+
+Wizard.prototype.getMode = function() {
+  return this.initForm['ConfigMode'].value;
+};
+
+function moveStep(direction) {
+  // if a next/prev step exists, call current step-related exit function
+  // and set new current step
+  if (this.steps[this.currentStep][direction]) {
+    if (this.steps[this.currentStep].exitFn) {
+      this.steps[this.currentStep].exitFn(function(err, res) {
         if (err) {
-            switch (lastMessageSent) {
-                case 'OKSETPIN':
-                    setNewCurrentStep.call(onlyKeyConfigWizard, 'Step3');
-                    break;
-                case 'OKSETSDPIN':
-                    setNewCurrentStep.call(onlyKeyConfigWizard, 'Step5');
-                    break;
-                case 'OKSETPDPIN':
-                    setNewCurrentStep.call(onlyKeyConfigWizard, 'Step7');
-                    break;
-            }
+          console.error(err);
+          goBackOnError(err, res);
+        } else if (res !== 'STOP') {
+          setNewCurrentStep.call(this, this.steps[this.currentStep][direction]);
         }
+      }.bind(this));
+    } else {
+      setNewCurrentStep.call(this, this.steps[this.currentStep][direction]);
     }
+  }
 
-    function setNewCurrentStep(stepId) {
-        this.currentStep = stepId;
-        setActiveStepUI.call(this);
+  return false;
+}
 
-        // call new current step-related enter function
-        if (this.steps[stepId].enterFn) {
-            this.steps[stepId].enterFn(function (err, res) {
-                if (err) {
-                    console.error(err);
-                } else {
-                    console.info(res);
-                }
-            });
-        }
+function goBackOnError(err, lastMessageSent) {
+  console.info(err, lastMessageSent);
+  if (err) {
+    switch (lastMessageSent) {
+      case 'OKSETPIN':
+        setNewCurrentStep.call(onlyKeyConfigWizard, 'Step3');
+        break;
+      case 'OKSETSDPIN':
+        setNewCurrentStep.call(onlyKeyConfigWizard, 'Step5');
+        break;
+      case 'OKSETPDPIN':
+        setNewCurrentStep.call(onlyKeyConfigWizard, 'Step7');
+        break;
     }
+  }
+}
 
-    function setActiveStepUI() {
-        // set display style for all steps
-        for(var stepId in this.steps) {
-            var el = document.getElementById(stepId);
-            if (el) {
-                // el.style.display = (stepId === this.currentStep ? '' : 'none');
-                if (stepId === this.currentStep) {
-                    el.classList.add('active');
-                } else {
-                    el.classList.remove('active');
-                }
-            }
-        }
+function setNewCurrentStep(stepId) {
+  this.currentStep = stepId;
+  setActiveStepUI.call(this);
 
-        var header = document.getElementById('HeaderTable');
-        var tabs = header.getElementsByTagName("td");
+  // call new current step-related enter function
+  if (this.steps[stepId].enterFn) {
+    this.steps[stepId].enterFn(function(err, res) {
+      if (err) {
+        console.error(err);
+      } else {
+        console.info(res);
+      }
+    });
+  }
+}
 
-        for (var i = 0; i < tabs.length; i++) {
-            if(tabs[i].getAttribute("data-step") === this.currentStep) {
-                tabs[i].classList.add('active');
-            } else {
-                    tabs[i].classList.remove('active');
-            }
-        }
-
-        if (this.steps[this.currentStep].next) {
-            this.btnNext.removeAttribute('disabled');
-        } else {
-            this.btnNext.setAttribute('disabled', 'disabled');
-        }
-
-        if (this.steps[this.currentStep].prev) {
-            this.btnPrev.removeAttribute('disabled');
-        } else {
-            this.btnPrev.setAttribute('disabled', 'disabled');
-        }
-        return false;
+function setActiveStepUI() {
+  // set display style for all steps
+  for (var stepId in this.steps) {
+    var el = document.getElementById(stepId);
+    if (el) {
+      // el.style.display = (stepId === this.currentStep ? '' : 'none');
+      if (stepId === this.currentStep) {
+        el.classList.add('active');
+      } else {
+        el.classList.remove('active');
+      }
     }
+  }
 
-    Wizard.prototype.setLastMessages = function (messages) {
-        var container = document.getElementById('lastMessage');
-        var messageListItems = container.getElementsByTagName('li');
+  var header = document.getElementById('HeaderTable');
+  var tabs = header.getElementsByTagName('td');
 
-        container.getElementsByTagName('span')[0].innerText = messages[0].text;
-        if (messages[1]) messageListItems[0].innerText = messages[1].text;
-        if (messages[2]) messageListItems[1].innerText = messages[2].text;
-    };
+  for (var i = 0; i < tabs.length; i++) {
+    if (tabs[i].getAttribute('data-step') === this.currentStep) {
+      tabs[i].classList.add('active');
+    } else {
+      tabs[i].classList.remove('active');
+    }
+  }
 
-    Wizard.prototype.setSlotLabel = function (slot, label) {
-        var slotLabel;
-        if (typeof slot === 'number') {
-            slot = slot;
-            var slotLabels = Array.from(document.getElementsByClassName('slotLabel'));
-            slotLabel = slotLabels[slot];
-        } else {
-            slot = slot.toLowerCase();
-            slotLabel = document.getElementById('slotLabel' + slot);
-        }
-        slotLabel.innerText = label;
-    };
+  if (this.steps[this.currentStep].next) {
+    this.btnNext.removeAttribute('disabled');
+  } else {
+    this.btnNext.setAttribute('disabled', 'disabled');
+  }
 
-    document.addEventListener('DOMContentLoaded', function init() {
-        console.info("Creating wizard instance...");
-        onlyKeyConfigWizard = new Wizard();
-        OnlyKeyHID(onlyKeyConfigWizard);
-    }, false);
+  if (this.steps[this.currentStep].prev) {
+    this.btnPrev.removeAttribute('disabled');
+  } else {
+    this.btnPrev.setAttribute('disabled', 'disabled');
+  }
+  return false;
+}
+
+Wizard.prototype.setLastMessages = function(messages) {
+  var container = document.getElementById('lastMessage');
+  var messageListItems = container.getElementsByTagName('li');
+
+  container.getElementsByTagName('span')[0].innerText = messages[0].text;
+  if (messages[1]) messageListItems[0].innerText = messages[1].text;
+  if (messages[2]) messageListItems[1].innerText = messages[2].text;
+};
+
+Wizard.prototype.setSlotLabel = function(slot, label) {
+  var slotLabel;
+  if (typeof slot === 'number') {
+    slot = slot;
+    var slotLabels = Array.from(document.getElementsByClassName('slotLabel'));
+    slotLabel = slotLabels[slot];
+  } else {
+    slot = slot.toLowerCase();
+    slotLabel = document.getElementById('slotLabel' + slot);
+  }
+  slotLabel.innerText = label;
+};
+
+document.addEventListener('DOMContentLoaded', function init() {
+  console.info('Creating wizard instance...');
+  onlyKeyConfigWizard = new Wizard();
+  OnlyKeyHID(onlyKeyConfigWizard);
+}, false);
 })();
 
 function dialogMgr() {
-    var self = this;
-    self.open = function (el, keepOthersOpen) {
-        if (!keepOthersOpen) {
-            self.closeAll();
-        }
-        if (!el.open) {
-            el.showModal();
-        }
-    };
+  var self = this;
+  self.open = function(el, keepOthersOpen) {
+    if (!keepOthersOpen) {
+      self.closeAll();
+    }
+    if (!el.open) {
+      el.showModal();
+    }
+  };
 
-    self.close = function (el) {
-        if (el.open) {
-            el.close();
-        }
-    };
+  self.close = function(el) {
+    if (el.open) {
+      el.close();
+    }
+  };
 
-    self.closeAll = function () {
-        var allDialogs = document.getElementsByTagName('dialog');
-        for (var i = 0; i < allDialogs.length; i++) {
-            self.close(allDialogs[i]);
-        }
-    };
+  self.closeAll = function() {
+    var allDialogs = document.getElementsByTagName('dialog');
+    for (var i = 0; i < allDialogs.length; i++) {
+      self.close(allDialogs[i]);
+    }
+  };
 }
 
 function clearRadios(name) {
-    var btns = document.getElementsByName(name);
-    for (var i = 0; i < btns.length; i++) {
-        if(btns[i].checked) btns[i].checked = false;
-    }
+  var btns = document.getElementsByName(name);
+  for (var i = 0; i < btns.length; i++) {
+    if (btns[i].checked) btns[i].checked = false;
+  }
 }
 
 function makeRadioButton(name, value, text) {
-    var label = document.createElement("label");
-    var radio = document.createElement("input");
-    radio.type = "radio";
-    radio.name = name;
-    radio.value = value;
+  var label = document.createElement('label');
+  var radio = document.createElement('input');
+  radio.type = 'radio';
+  radio.name = name;
+  radio.value = value;
 
-    label.appendChild(radio);
-    label.appendChild(document.createTextNode(text));
-    return label;
+  label.appendChild(radio);
+  label.appendChild(document.createTextNode(text));
+  return label;
 }

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -12,24 +12,22 @@ var rootDir = projectDir.cwd('./');
 var destDir = projectDir.cwd('./build');
 
 var paths = {
-    jsCodeToTranspile: [
-        'app/scripts/**/*.js',
-        'app/*.js',
-    ],
-    filesToCopyFromAppDir: [
-        'images/**/*',
-        'stylesheets/**/*',
-        'vendor/**/*',
-        '*.html',
-    ],
-    filesToCopyFromRootDir: [],
+  jsCodeToTranspile: [
+    'app/scripts/**/*.js',
+    'app/*.js',
+  ],
+  filesToCopyFromAppDir: [
+    'images/**/*',
+    'stylesheets/**/*',
+    'vendor/**/*',
+    '*.html',
+  ],
+  filesToCopyFromRootDir: [],
 };
 
 if (utils.getEnvName() === 'chrome') {
-    paths.filesToCopyFromRootDir.push(
-        'manifest.json',
-        'resources/onlykey_logo_*.png'
-    );
+  paths.filesToCopyFromRootDir.push(
+      'manifest.json', 'resources/onlykey_logo_*.png');
 }
 
 // -------------------------------------
@@ -37,70 +35,71 @@ if (utils.getEnvName() === 'chrome') {
 // -------------------------------------
 
 gulp.task('clean', function(callback) {
-    return destDir.dirAsync('.', { empty: true });
+  return destDir.dirAsync('.', {empty: true});
 });
 
 
-var copyTask = function () {
-    projectDir.copy('resources/onlykey_logo_128.png', destDir.path('icon.png'), { overwrite: true });
+var copyTask = function() {
+  projectDir.copy(
+      'resources/onlykey_logo_128.png', destDir.path('icon.png'),
+      {overwrite: true});
 
-    var result = jetpack.copyAsync(projectDir.path('app'), destDir.path(), {
-        overwrite: true,
-        matching: paths.filesToCopyFromAppDir
-    });
-    result = result.then(() => {
-        return jetpack.copyAsync(projectDir.path(), destDir.path(), {
-            overwrite: true,
-            matching: paths.filesToCopyFromRootDir
-        });
-    });
-    return result;
+  var result = jetpack.copyAsync(
+      projectDir.path('app'), destDir.path(),
+      {overwrite: true, matching: paths.filesToCopyFromAppDir});
+  result = result.then(() => {
+    return jetpack.copyAsync(
+        projectDir.path(), destDir.path(),
+        {overwrite: true, matching: paths.filesToCopyFromRootDir});
+  });
+  return result;
 };
 gulp.task('copy', ['clean'], copyTask);
 gulp.task('copy-watch', copyTask);
 
 
-var transpileTask = function () {
-    return gulp.src(paths.jsCodeToTranspile, { base: 'app' })
-    .pipe(sourcemaps.init())
-    .pipe(sourcemaps.write('.'))
-    .pipe(gulp.dest(destDir.path()));
+var transpileTask = function() {
+  return gulp.src(paths.jsCodeToTranspile, {base: 'app'})
+      .pipe(sourcemaps.init())
+      .pipe(sourcemaps.write('.'))
+      .pipe(gulp.dest(destDir.path()));
 };
 gulp.task('transpile', ['clean'], transpileTask);
 gulp.task('transpile-watch', transpileTask);
 
 
 // Add and customize OS-specific and target-specific stuff.
-gulp.task('finalize', ['clean'], function () {
-    var manifest = rootDir.read('package.json', 'json');
-    switch (utils.getEnvName()) {
-        case 'production':
-            // Hide dev toolbar if doing a release.
-            manifest.window.toolbar = false;
-            break;
-        case 'test':
-            // Add "-test" suffix to name, so NW.js will write all
-            // data like cookies and locaStorage into separate place.
-            manifest.name += '-test';
-            // TODO: Change manifest.main to launch a test runner?
-            break;
-        case 'development':
-            // Add "-dev" suffix to name, so NW.js will write all
-            // data like cookies and locaStorage into separate place.
-            manifest.name += '-dev';
-            break;
-    }
-    destDir.write('package.json', manifest);
+gulp.task('finalize', ['clean'], function() {
+  var manifest = rootDir.read('package.json', 'json');
+  switch (utils.getEnvName()) {
+    case 'production':
+      // Hide dev toolbar if doing a release.
+      manifest.window.toolbar = false;
+      break;
+    case 'test':
+      // Add "-test" suffix to name, so NW.js will write all
+      // data like cookies and locaStorage into separate place.
+      manifest.name += '-test';
+      // TODO: Change manifest.main to launch a test runner?
+      break;
+    case 'development':
+      // Add "-dev" suffix to name, so NW.js will write all
+      // data like cookies and locaStorage into separate place.
+      manifest.name += '-dev';
+      break;
+  }
+  destDir.write('package.json', manifest);
 
-    var configFilePath = projectDir.path('config/env_' + utils.getEnvName() + '.json');
-    destDir.copy(configFilePath, 'env_config.json');
+  var configFilePath =
+      projectDir.path('config/env_' + utils.getEnvName() + '.json');
+  destDir.copy(configFilePath, 'env_config.json');
 });
 
 
-gulp.task('watch', function () {
-    gulp.watch(paths.jsCodeToTranspile, ['transpile-watch']);
-    gulp.watch(paths.filesToCopyFromRootDir, ['copy-watch']);
-    gulp.watch(paths.filesToCopyFromAppDir, { cwd: 'app' }, ['copy-watch']);
+gulp.task('watch', function() {
+  gulp.watch(paths.jsCodeToTranspile, ['transpile-watch']);
+  gulp.watch(paths.filesToCopyFromRootDir, ['copy-watch']);
+  gulp.watch(paths.filesToCopyFromAppDir, {cwd: 'app'}, ['copy-watch']);
 });
 
 

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -4,11 +4,11 @@ var gulp = require('gulp');
 var utils = require('./utils');
 
 var releaseForOs = {
-    osx: require('./release_osx'),
-    linux: require('./release_linux'),
-    windows: require('./release_windows'),
+  osx: require('./release_osx'),
+  linux: require('./release_linux'),
+  windows: require('./release_windows'),
 };
 
-gulp.task('release', ['build'], function () {
-    return releaseForOs[utils.os()]();
+gulp.task('release', ['build'], function() {
+  return releaseForOs[utils.os()]();
 });

--- a/tasks/release_linux.js
+++ b/tasks/release_linux.js
@@ -14,88 +14,91 @@ var tmpDir;
 var readyAppDir;
 var manifest;
 
-var init = function () {
-    projectDir = jetpack;
-    tmpDir = projectDir.dir('./tmp', { empty: true });
-    releasesDir = projectDir.dir('./releases');
-    manifest = projectDir.read('package.json', 'json');
-    packName = manifest.name + '_' + manifest.version;
-    packDir = tmpDir.dir(packName);
-    readyAppDir = packDir.cwd('opt', manifest.name);
+var init = function() {
+  projectDir = jetpack;
+  tmpDir = projectDir.dir('./tmp', {empty: true});
+  releasesDir = projectDir.dir('./releases');
+  manifest = projectDir.read('package.json', 'json');
+  packName = manifest.name + '_' + manifest.version;
+  packDir = tmpDir.dir(packName);
+  readyAppDir = packDir.cwd('opt', manifest.name);
 
-    return Q();
+  return Q();
 };
 
-var copyRuntime = function () {
-    return projectDir.copyAsync('node_modules/nw/nwjs', readyAppDir.path(), { overwrite: true });
+var copyRuntime = function() {
+  return projectDir.copyAsync(
+      'node_modules/nw/nwjs', readyAppDir.path(), {overwrite: true});
 };
 
-var copyBuiltApp = function () {
-    return projectDir.copyAsync('build', readyAppDir.path(), { overwrite: true });
+var copyBuiltApp = function() {
+  return projectDir.copyAsync('build', readyAppDir.path(), {overwrite: true});
 };
 
-var prepareOsSpecificThings = function () {
-    // Create .desktop file from the template
-    var desktop = projectDir.read('resources/linux/app.desktop');
-    desktop = utils.replace(desktop, {
-        name: manifest.name,
-        productName: manifest.productName,
-        description: manifest.description,
-        version: manifest.version,
-        author: manifest.author
-    });
-    packDir.write('usr/share/applications/' + manifest.name + '.desktop', desktop);
+var prepareOsSpecificThings = function() {
+  // Create .desktop file from the template
+  var desktop = projectDir.read('resources/linux/app.desktop');
+  desktop = utils.replace(desktop, {
+    name: manifest.name,
+    productName: manifest.productName,
+    description: manifest.description,
+    version: manifest.version,
+    author: manifest.author
+  });
+  packDir.write(
+      'usr/share/applications/' + manifest.name + '.desktop', desktop);
 
-    return Q();
+  return Q();
 };
 
-var packToDebFile = function () {
-    var deferred = Q.defer();
+var packToDebFile = function() {
+  var deferred = Q.defer();
 
-    var debFileName = packName + '_amd64.deb';
-    var debPath = releasesDir.path(debFileName);
+  var debFileName = packName + '_amd64.deb';
+  var debPath = releasesDir.path(debFileName);
 
-    gulpUtil.log('Creating DEB package...');
+  gulpUtil.log('Creating DEB package...');
 
-    // Counting size of the app in KiB
-    var appSize = Math.round(readyAppDir.inspectTree('.').size / 1024);
+  // Counting size of the app in KiB
+  var appSize = Math.round(readyAppDir.inspectTree('.').size / 1024);
 
-    // Preparing debian control file
-    var control = projectDir.read('resources/linux/DEBIAN/control');
-    control = utils.replace(control, {
-        name: manifest.name,
-        description: manifest.description,
-        version: manifest.version,
-        author: manifest.author,
-        size: appSize
-    });
-    packDir.write('DEBIAN/control', control);
+  // Preparing debian control file
+  var control = projectDir.read('resources/linux/DEBIAN/control');
+  control = utils.replace(control, {
+    name: manifest.name,
+    description: manifest.description,
+    version: manifest.version,
+    author: manifest.author,
+    size: appSize
+  });
+  packDir.write('DEBIAN/control', control);
 
-    // Build the package...
-    childProcess.exec('fakeroot dpkg-deb -Zxz --build ' + packDir.path() + ' ' + debPath,
-        function (error, stdout, stderr) {
-            if (error || stderr) {
-                console.log("ERROR while building DEB package:");
-                console.log(error);
-                console.log(stderr);
-            } else {
-                gulpUtil.log('DEB package ready!', debPath);
-            }
-            deferred.resolve();
-        });
+  // Build the package...
+  childProcess.exec(
+      'fakeroot dpkg-deb -Zxz --build ' + packDir.path() + ' ' + debPath,
+      function(error, stdout, stderr) {
+        if (error || stderr) {
+          console.log('ERROR while building DEB package:');
+          console.log(error);
+          console.log(stderr);
+        } else {
+          gulpUtil.log('DEB package ready!', debPath);
+        }
+        deferred.resolve();
+      });
 
-    return deferred.promise;
+  return deferred.promise;
 };
 
-var cleanClutter = function () {
-    return tmpDir.removeAsync('.');
+var cleanClutter = function() {
+  return tmpDir.removeAsync('.');
 };
 
-module.exports = function () {
-    return init()
-    .then(copyRuntime)
-    .then(copyBuiltApp)
-    .then(prepareOsSpecificThings)
-    .then(packToDebFile)
-    .then(cleanClutter);
+module.exports = function() {
+  return init()
+      .then(copyRuntime)
+      .then(copyBuiltApp)
+      .then(prepareOsSpecificThings)
+      .then(packToDebFile)
+      .then(cleanClutter);
 };

--- a/tasks/release_osx.js
+++ b/tasks/release_osx.js
@@ -12,93 +12,92 @@ var tmpDir;
 var finalAppDir;
 var manifest;
 
-var init = function () {
-    projectDir = jetpack;
-    tmpDir = projectDir.dir('./tmp', { empty: true });
-    releasesDir = projectDir.dir('./releases');
-    manifest = projectDir.read('package.json', 'json');
-    finalAppDir = tmpDir.cwd(manifest.productName + '.app');
+var init = function() {
+  projectDir = jetpack;
+  tmpDir = projectDir.dir('./tmp', {empty: true});
+  releasesDir = projectDir.dir('./releases');
+  manifest = projectDir.read('package.json', 'json');
+  finalAppDir = tmpDir.cwd(manifest.productName + '.app');
 
-    return Q();
+  return Q();
 };
 
-var copyRuntime = function () {
-    // When copying files, ignore `ljproj` files. Otherwise, the application
-    // name will show up as 'nwjs'. Thanks to
-    // https://github.com/nwjs-community/nw-builder/
-    return projectDir.copyAsync('node_modules/nw/nwjs/nwjs.app',
-                                finalAppDir.path(),
-                                { matching: ['Contents/**/*', '!Contents/Resources/*.lproj/*'] });
+var copyRuntime = function() {
+  // When copying files, ignore `ljproj` files. Otherwise, the application
+  // name will show up as 'nwjs'. Thanks to
+  // https://github.com/nwjs-community/nw-builder/
+  return projectDir.copyAsync(
+      'node_modules/nw/nwjs/nwjs.app', finalAppDir.path(),
+      {matching: ['Contents/**/*', '!Contents/Resources/*.lproj/*']});
 };
 
-var copyBuiltApp = function () {
-    return projectDir.copyAsync('build', finalAppDir.path('Contents/Resources/app.nw'));
+var copyBuiltApp = function() {
+  return projectDir.copyAsync(
+      'build', finalAppDir.path('Contents/Resources/app.nw'));
 };
 
-var prepareOsSpecificThings = function () {
-    // Info.plist
-    var info = projectDir.read('resources/osx/Info.plist');
-    info = utils.replace(info, {
-        productName: manifest.productName,
-        version: manifest.version
-    });
-    finalAppDir.write('Contents/Info.plist', info);
+var prepareOsSpecificThings = function() {
+  // Info.plist
+  var info = projectDir.read('resources/osx/Info.plist');
+  info = utils.replace(
+      info, {productName: manifest.productName, version: manifest.version});
+  finalAppDir.write('Contents/Info.plist', info);
 
-    // Icon
-    projectDir.copy('resources/osx/icon.icns', finalAppDir.path('Contents/Resources/icon.icns'));
+  // Icon
+  projectDir.copy(
+      'resources/osx/icon.icns',
+      finalAppDir.path('Contents/Resources/icon.icns'));
 
-    // Rename executable, so it looks nice in the installer
-    jetpack.rename(finalAppDir.path('Contents/MacOS/nwjs'), manifest.productName);
+  // Rename executable, so it looks nice in the installer
+  jetpack.rename(finalAppDir.path('Contents/MacOS/nwjs'), manifest.productName);
 
-    return Q();
+  return Q();
 };
 
-var packToDmgFile = function () {
-    var deferred = Q.defer();
+var packToDmgFile = function() {
+  var deferred = Q.defer();
 
-    var appdmg = require('appdmg');
-    var dmgName = manifest.name + '_' + manifest.version + '.dmg';
+  var appdmg = require('appdmg');
+  var dmgName = manifest.name + '_' + manifest.version + '.dmg';
 
-    // Prepare appdmg config
-    var dmgManifest = projectDir.read('resources/osx/appdmg.json');
-    dmgManifest = utils.replace(dmgManifest, {
-        productName: manifest.productName,
-        appPath: finalAppDir.path(),
-        dmgIcon: projectDir.path("resources/osx/dmg-icon.icns"),
-        dmgBackground: projectDir.path("resources/osx/dmg-background.png")
-    });
-    tmpDir.write('appdmg.json', dmgManifest);
+  // Prepare appdmg config
+  var dmgManifest = projectDir.read('resources/osx/appdmg.json');
+  dmgManifest = utils.replace(dmgManifest, {
+    productName: manifest.productName,
+    appPath: finalAppDir.path(),
+    dmgIcon: projectDir.path('resources/osx/dmg-icon.icns'),
+    dmgBackground: projectDir.path('resources/osx/dmg-background.png')
+  });
+  tmpDir.write('appdmg.json', dmgManifest);
 
-    // Delete DMG file with this name if already exists
-    releasesDir.remove(dmgName);
+  // Delete DMG file with this name if already exists
+  releasesDir.remove(dmgName);
 
-    gulpUtil.log('Packaging to DMG file...');
+  gulpUtil.log('Packaging to DMG file...');
 
-    var readyDmgPath = releasesDir.path(dmgName);
-    appdmg({
-        source: tmpDir.path('appdmg.json'),
-        target: readyDmgPath
-    })
-    .on('error', function (err) {
-        console.error(err);
-    })
-    .on('finish', function () {
+  var readyDmgPath = releasesDir.path(dmgName);
+  appdmg({source: tmpDir.path('appdmg.json'), target: readyDmgPath})
+      .on('error',
+          function(err) {
+            console.error(err);
+          })
+      .on('finish', function() {
         gulpUtil.log('DMG file ready!', readyDmgPath);
         deferred.resolve();
-    });
+      });
 
-    return deferred.promise;
+  return deferred.promise;
 };
 
-var cleanClutter = function () {
-    return tmpDir.removeAsync('.');
+var cleanClutter = function() {
+  return tmpDir.removeAsync('.');
 };
 
-module.exports = function () {
-    return init()
-    .then(copyRuntime)
-    .then(copyBuiltApp)
-    .then(prepareOsSpecificThings)
-    .then(packToDmgFile)
-    .then(cleanClutter);
+module.exports = function() {
+  return init()
+      .then(copyRuntime)
+      .then(copyBuiltApp)
+      .then(prepareOsSpecificThings)
+      .then(packToDmgFile)
+      .then(cleanClutter);
 };

--- a/tasks/release_windows.js
+++ b/tasks/release_windows.js
@@ -12,71 +12,73 @@ var releasesDir;
 var readyAppDir;
 var manifest;
 
-var init = function () {
-    projectDir = jetpack;
-    tmpDir = projectDir.dir('./tmp', { empty: true });
-    releasesDir = projectDir.dir('./releases');
-    manifest = projectDir.read('package.json', 'json');
-    readyAppDir = tmpDir.cwd(manifest.name);
+var init = function() {
+  projectDir = jetpack;
+  tmpDir = projectDir.dir('./tmp', {empty: true});
+  releasesDir = projectDir.dir('./releases');
+  manifest = projectDir.read('package.json', 'json');
+  readyAppDir = tmpDir.cwd(manifest.name);
 
-    return Q();
+  return Q();
 };
 
-var copyRuntime = function () {
-    return projectDir.copyAsync('node_modules/nw/nwjs', readyAppDir.path(), { overwrite: true });
+var copyRuntime = function() {
+  return projectDir.copyAsync(
+      'node_modules/nw/nwjs', readyAppDir.path(), {overwrite: true});
 };
 
-var copyBuiltApp = function () {
-    return projectDir.copyAsync('build', readyAppDir.path(), { overwrite: true });
+var copyBuiltApp = function() {
+  return projectDir.copyAsync('build', readyAppDir.path(), {overwrite: true});
 };
 
-var prepareOsSpecificThings = function () {
-    return projectDir.copyAsync('resources/windows/icon.ico', readyAppDir.path('icon.ico'));
+var prepareOsSpecificThings = function() {
+  return projectDir.copyAsync(
+      'resources/windows/icon.ico', readyAppDir.path('icon.ico'));
 };
 
-var createInstaller = function () {
-    var deferred = Q.defer();
+var createInstaller = function() {
+  var deferred = Q.defer();
 
-    var finalPackageName = manifest.name + '_' + manifest.version + '.exe';
-    var installScript = projectDir.read('resources/windows/installer.nsi');
-    installScript = utils.replace(installScript, {
-        name: manifest.name,
-        productName: manifest.productName,
-        version: manifest.version,
-        src: readyAppDir.path(),
-        dest: releasesDir.path(finalPackageName),
-        icon: readyAppDir.path('icon.ico'),
-        setupIcon: projectDir.path('resources/windows/setup-icon.ico'),
-        banner: projectDir.path('resources/windows/setup-banner.bmp'),
-    });
-    tmpDir.write('installer.nsi', installScript);
+  var finalPackageName = manifest.name + '_' + manifest.version + '.exe';
+  var installScript = projectDir.read('resources/windows/installer.nsi');
+  installScript = utils.replace(installScript, {
+    name: manifest.name,
+    productName: manifest.productName,
+    version: manifest.version,
+    src: readyAppDir.path(),
+    dest: releasesDir.path(finalPackageName),
+    icon: readyAppDir.path('icon.ico'),
+    setupIcon: projectDir.path('resources/windows/setup-icon.ico'),
+    banner: projectDir.path('resources/windows/setup-banner.bmp'),
+  });
+  tmpDir.write('installer.nsi', installScript);
 
-    gulpUtil.log('Building installer with NSIS...');
+  gulpUtil.log('Building installer with NSIS...');
 
-    // Remove destination file if already exists.
-    releasesDir.remove(finalPackageName);
+  // Remove destination file if already exists.
+  releasesDir.remove(finalPackageName);
 
-    // Note: NSIS have to be added to PATH (environment variables).
-    var nsis = childProcess.spawn('makensis', [tmpDir.path('installer.nsi')]);
-    nsis.stdout.pipe(process.stdout);
-    nsis.stderr.pipe(process.stderr);
-    nsis.on('close', function () {
-        gulpUtil.log('Installer ready!', releasesDir.path(finalPackageName));
-        deferred.resolve();
-    });
+  // Note: NSIS have to be added to PATH (environment variables).
+  var nsis = childProcess.spawn('makensis', [tmpDir.path('installer.nsi')]);
+  nsis.stdout.pipe(process.stdout);
+  nsis.stderr.pipe(process.stderr);
+  nsis.on('close', function() {
+    gulpUtil.log('Installer ready!', releasesDir.path(finalPackageName));
+    deferred.resolve();
+  });
 
-    return deferred.promise;
+  return deferred.promise;
 };
 
-var cleanClutter = function () {
-    return tmpDir.removeAsync('.');
+var cleanClutter = function() {
+  return tmpDir.removeAsync('.');
 };
 
-module.exports = function () {
-    return init()
-    .then(copyRuntime)
-    .then(copyBuiltApp)
-    .then(prepareOsSpecificThings)
-    .then(createInstaller)
-    .then(cleanClutter);
+module.exports = function() {
+  return init()
+      .then(copyRuntime)
+      .then(copyBuiltApp)
+      .then(prepareOsSpecificThings)
+      .then(createInstaller)
+      .then(cleanClutter);
 };

--- a/tasks/start.js
+++ b/tasks/start.js
@@ -10,58 +10,47 @@ var watch;
 
 var gulpPath = pathUtil.resolve('./node_modules/.bin/gulp');
 if (process.platform === 'win32') {
-    gulpPath += '.cmd';
+  gulpPath += '.cmd';
 }
 
-var runBuild = function () {
-    var deferred = Q.defer();
+var runBuild = function() {
+  var deferred = Q.defer();
 
-    var build = childProcess.spawn(gulpPath, [
-        'build',
-        '--env=' + utils.getEnvName(),
-        '--color'
-    ], {
-        stdio: 'inherit'
-    });
+  var build = childProcess.spawn(
+      gulpPath, ['build', '--env=' + utils.getEnvName(), '--color'],
+      {stdio: 'inherit'});
 
-    build.on('close', function (code) {
-        deferred.resolve();
-    });
+  build.on('close', function(code) {
+    deferred.resolve();
+  });
 
-    return deferred.promise;
+  return deferred.promise;
 };
 
-var runGulpWatch = function () {
-    watch = childProcess.spawn(gulpPath, [
-        'watch',
-        '--env=' + utils.getEnvName(),
-        '--color'
-    ], {
-        stdio: 'inherit'
-    });
+var runGulpWatch = function() {
+  watch = childProcess.spawn(
+      gulpPath, ['watch', '--env=' + utils.getEnvName(), '--color'],
+      {stdio: 'inherit'});
 
-    watch.on('close', function (code) {
-        // Gulp watch exits when error occured during build.
-        // Just respawn it then.
-        runGulpWatch();
-    });
-};
-
-var runApp = function () {
-    var app = childProcess.spawn(nw.findpath(), ['./build'], {
-        stdio: 'inherit'
-    });
-
-    app.on('close', function (code) {
-        // User closed the app. Kill the host process.
-        kill(watch.pid, 'SIGKILL', function () {
-            process.exit();
-        });
-    });
-};
-
-runBuild()
-.then(function () {
+  watch.on('close', function(code) {
+    // Gulp watch exits when error occured during build.
+    // Just respawn it then.
     runGulpWatch();
-    runApp();
+  });
+};
+
+var runApp = function() {
+  var app = childProcess.spawn(nw.findpath(), ['./build'], {stdio: 'inherit'});
+
+  app.on('close', function(code) {
+    // User closed the app. Kill the host process.
+    kill(watch.pid, 'SIGKILL', function() {
+      process.exit();
+    });
+  });
+};
+
+runBuild().then(function() {
+  runGulpWatch();
+  runApp();
 });

--- a/tasks/utils.js
+++ b/tasks/utils.js
@@ -4,26 +4,26 @@ var argv = require('yargs').argv;
 var os = require('os');
 var jetpack = require('fs-jetpack');
 
-module.exports.os = function () {
-    switch (os.platform()) {
-        case 'darwin':
-            return 'osx';
-        case 'linux':
-            return 'linux';
-        case 'win32':
-            return 'windows';
-    }
-    return 'unsupported';
+module.exports.os = function() {
+  switch (os.platform()) {
+    case 'darwin':
+      return 'osx';
+    case 'linux':
+      return 'linux';
+    case 'win32':
+      return 'windows';
+  }
+  return 'unsupported';
 };
 
-module.exports.replace = function (str, patterns) {
-    Object.keys(patterns).forEach(function (pattern) {
-        var matcher = new RegExp('{{' + pattern + '}}', 'g');
-        str = str.replace(matcher, patterns[pattern]);
-    });
-    return str;
+module.exports.replace = function(str, patterns) {
+  Object.keys(patterns).forEach(function(pattern) {
+    var matcher = new RegExp('{{' + pattern + '}}', 'g');
+    str = str.replace(matcher, patterns[pattern]);
+  });
+  return str;
 };
 
-module.exports.getEnvName = function () {
-    return argv.env || 'development';
+module.exports.getEnvName = function() {
+  return argv.env || 'development';
 };

--- a/test/configure-slot-test.js
+++ b/test/configure-slot-test.js
@@ -11,95 +11,98 @@ chai.use(chaiAsPromised);
 
 describe('Configuring a slot on the OnlyKey', function() {
 
-    function expectDialogOpen(id) {
-        let dialog = driver.findElement(By.id(id));
-        return expect(dialog.getAttribute('open')).to.eventually.equal('true');
+  function expectDialogOpen(id) {
+    let dialog = driver.findElement(By.id(id));
+    return expect(dialog.getAttribute('open')).to.eventually.equal('true');
+  }
+
+  function expectDialogClosed(id) {
+    let dialog = driver.findElement(By.id(id));
+    return expect(dialog.getAttribute('open')).to.eventually.equal(null);
+  }
+
+  function messageToBuffer(msg) {
+    let result = new Uint8Array(64);
+    for (let i = 0; i < Math.min(msg.length, result.length); ++i) {
+      result[i] = msg.charCodeAt(i);
     }
+    return result;
+  }
 
-    function expectDialogClosed(id) {
-        let dialog = driver.findElement(By.id(id));
-        return expect(dialog.getAttribute('open')).to.eventually.equal(null);
-    }
+  it('should start disconnected', function() {
+    driver.navigate().refresh();
+    driver.wait(until.titleIs('OnlyKey Configuration Wizard'));
+    return expectDialogOpen('disconnected-dialog');
+  });
 
-    function messageToBuffer(msg) {
-        let result = new Uint8Array(64);
-        for (let i = 0; i < Math.min(msg.length, result.length); ++i) {
-            result[i] = msg.charCodeAt(i);
-        }
-        return result;
-    }
+  it('should not show "working..." on startup', function() {
+    return expectDialogClosed('working-dialog');
+  });
 
-    it('should start disconnected', function() {
-        driver.navigate().refresh();
-        driver.wait(until.titleIs('OnlyKey Configuration Wizard'));
-        return expectDialogOpen('disconnected-dialog');
+  it('should show "working..." once a device is connected', function() {
+    driver.executeScript(function() {
+      chromeHid.onDeviceAdded.mockDeviceAdded();
     });
+    return expectDialogOpen('working-dialog');
+  });
 
-    it('should not show "working..." on startup', function() {
-        return expectDialogClosed('working-dialog');
-    });
+  it('should ask users to unlock the key', function() {
+    driver.executeScript(function(msg) {
+      chromeHid.mockResponse([null, msg]);
+    }, messageToBuffer('INITIALIZED'));
+    return expectDialogOpen('locked-dialog');
+  });
 
-    it('should show "working..." once a device is connected', function() {
-        driver.executeScript(function() {
-            chromeHid.onDeviceAdded.mockDeviceAdded();
-        });
-        return expectDialogOpen('working-dialog');
-    });
-
-    it('should ask users to unlock the key', function() {
-        driver.executeScript(function(msg) {
+  it('should show slot config dialog after clicking button 1a', function() {
+    ['UNLOCKED', 'OK', 'UNLOCKEDv0.2-beta.3', '\0', '\x01|FooLabel', '\x02|',
+     '\x03|', '\x04|', '\x05|', '\x06|', '\x07|', '\x08|', '\x09|', '\x10|',
+     '\x11|', '\x12|']
+        .forEach(function(msgText) {
+          driver.executeScript(function(msg) {
             chromeHid.mockResponse([null, msg]);
-        }, messageToBuffer('INITIALIZED'));
-        return expectDialogOpen('locked-dialog');
-    });
-
-    it('should show slot config dialog after clicking button 1a', function() {
-        ['UNLOCKED', 'OK', 'UNLOCKEDv0.2-beta.3', '\0', '\x01|FooLabel', '\x02|',
-                '\x03|', '\x04|', '\x05|', '\x06|', '\x07|', '\x08|', '\x09|',
-                '\x10|', '\x11|', '\x12|'].forEach(function(msgText) {
-            driver.executeScript(function(msg) {
-                chromeHid.mockResponse([null, msg]);
-            }, messageToBuffer(msgText));
+          }, messageToBuffer(msgText));
         });
-        driver.findElement(By.id('slot1aConfig')).click();
-        return expectDialogOpen('slot-config-dialog');
+    driver.findElement(By.id('slot1aConfig')).click();
+    return expectDialogOpen('slot-config-dialog');
+  });
+
+  it('should show the correct label in the slot config dialog', function() {
+    let label = driver.findElement(By.id('txtSlotLabel'));
+    return expect(label.getAttribute('value')).to.eventually.equal('FooLabel');
+  });
+
+  it('should verify the password confirmation field', function() {
+    driver.findElement(By.id('chkPassword')).click();
+    driver.findElement(By.id('txtPassword')).sendKeys('FooPassword');
+    driver.findElement(By.id('slotSubmit')).click();
+    return expect(driver.findElement(By.id('slotConfigErrors')).getText())
+        .to.eventually.contain('Password fields do not match');
+  });
+
+  it('should send the newly set password to the OnlyKey', function() {
+    driver.findElement(By.id('txtPasswordConfirm')).sendKeys('FooPassword');
+    driver.findElement(By.id('slotSubmit')).click();
+
+    // We're expecting a password message containing [255, 255, 255, 255,
+    // SETSLOT=230, slotnumber=1, field=5 (PASSWORD), "FooPassword"]
+    let passwordMessage = driver.executeScript(function() {
+      return new Uint8Array(chromeHid._sent[chromeHid._sent.length - 3][2]);
     });
+    return expect(passwordMessage)
+        .to.eventually.deep.equal(Array.from(
+            messageToBuffer('\xff\xff\xff\xff\xe6\x01\x05FooPassword')));
+  });
 
-    it('should show the correct label in the slot config dialog', function() {
-        let label = driver.findElement(By.id('txtSlotLabel'));
-        return expect(label.getAttribute('value')).to.eventually.equal('FooLabel');
+  it('should send <Enter> after the password', function() {
+    // For some reason, it's also setting NEXTKEY3 to 2 (Return).
+    // FIXME is this a bug in the form? Should this be unchecked?
+    // Anyway, expecting [255, 255, 255, 255,
+    // SETSLOT=230, slotnumber=1, field=6 (NEXTKEY3), "2"]
+    let nextKey3Message = driver.executeScript(function() {
+      return new Uint8Array(chromeHid._sent[chromeHid._sent.length - 2][2]);
     });
-
-    it('should verify the password confirmation field', function() {
-        driver.findElement(By.id('chkPassword')).click();
-        driver.findElement(By.id('txtPassword')).sendKeys('FooPassword');
-        driver.findElement(By.id('slotSubmit')).click();
-        return expect(driver.findElement(By.id('slotConfigErrors')).getText())
-            .to.eventually.contain('Password fields do not match');
-    });
-
-    it('should send the newly set password to the OnlyKey', function() {
-        driver.findElement(By.id('txtPasswordConfirm')).sendKeys('FooPassword');
-        driver.findElement(By.id('slotSubmit')).click();
-
-        // We're expecting a password message containing [255, 255, 255, 255,
-        // SETSLOT=230, slotnumber=1, field=5 (PASSWORD), "FooPassword"]
-        let passwordMessage = driver.executeScript(function() {
-            return new Uint8Array(chromeHid._sent[chromeHid._sent.length - 3][2]);
-        });
-        return expect(passwordMessage).to.eventually.deep.equal(
-            Array.from(messageToBuffer('\xff\xff\xff\xff\xe6\x01\x05FooPassword')));
-    });
-
-    it('should send <Enter> after the password', function() {
-        // For some reason, it's also setting NEXTKEY3 to 2 (Return).
-        // FIXME is this a bug in the form? Should this be unchecked?
-        // Anyway, expecting [255, 255, 255, 255,
-        // SETSLOT=230, slotnumber=1, field=6 (NEXTKEY3), "2"]
-        let nextKey3Message = driver.executeScript(function() {
-            return new Uint8Array(chromeHid._sent[chromeHid._sent.length - 2][2]);
-        });
-        return expect(nextKey3Message).to.eventually.deep.equal(
+    return expect(nextKey3Message)
+        .to.eventually.deep.equal(
             Array.from(messageToBuffer('\xff\xff\xff\xff\xe6\x01\x062')));
-    });
+  });
 });

--- a/test/driver.js
+++ b/test/driver.js
@@ -6,23 +6,27 @@ const path = require('path');
 // includes an `after` hook to properly shut it down.
 
 function createDriver() {
-    // Use chromedriver that comes with nwjs
-    let service = new chrome.ServiceBuilder(path.join(path.dirname(require.resolve('nw')), 'nwjs', 'chromedriver')).build();
-    chrome.setDefaultService(service);
+  // Use chromedriver that comes with nwjs
+  let service =
+      new chrome
+          .ServiceBuilder(path.join(
+              path.dirname(require.resolve('nw')), 'nwjs', 'chromedriver'))
+          .build();
+  chrome.setDefaultService(service);
 
-    // Point chromedriver to the nwjs app
-    let options = new chrome.Options()
-        .addArguments('nwapp=' + path.join(path.dirname(__dirname), 'build'));
+  // Point chromedriver to the nwjs app
+  let options = new chrome.Options().addArguments(
+      'nwapp=' + path.join(path.dirname(__dirname), 'build'));
 
-    return new webdriver.Builder()
-        .withCapabilities(webdriver.Capabilities.chrome())
-        .setChromeOptions(options)
-        .build();
+  return new webdriver.Builder()
+      .withCapabilities(webdriver.Capabilities.chrome())
+      .setChromeOptions(options)
+      .build();
 }
 
 after(function() {
-    let driver = module.exports;
-    return driver.quit();
+  let driver = module.exports;
+  return driver.quit();
 });
 
 module.exports = createDriver();

--- a/test/startup-test.js
+++ b/test/startup-test.js
@@ -14,18 +14,19 @@ chai.use(chaiAsPromised);
 
 describe('OnlyKey Configuration', function() {
 
-    it('should start disconnected', function() {
-        driver.navigate().refresh();
-        driver.wait(until.titleIs('OnlyKey Configuration Wizard'));
+  it('should start disconnected', function() {
+    driver.navigate().refresh();
+    driver.wait(until.titleIs('OnlyKey Configuration Wizard'));
 
-        let disconnected = driver.findElement(By.id('disconnected-dialog'));
-        return expect(disconnected.getAttribute('open')).to.eventually.equal('true');
-    });
+    let disconnected = driver.findElement(By.id('disconnected-dialog'));
+    return expect(disconnected.getAttribute('open'))
+        .to.eventually.equal('true');
+  });
 
-    it('should not show "working..." dialog', function() {
-        driver.wait(until.titleIs('OnlyKey Configuration Wizard'));
+  it('should not show "working..." dialog', function() {
+    driver.wait(until.titleIs('OnlyKey Configuration Wizard'));
 
-        let working = driver.findElement(By.id('working-dialog'));
-        return expect(working.getAttribute('open')).to.eventually.equal(null);
-    });
+    let working = driver.findElement(By.id('working-dialog'));
+    return expect(working.getAttribute('open')).to.eventually.equal(null);
+  });
 });


### PR DESCRIPTION
This commit formats all our own source files according to the Google Javascript coding style.

There is one disadvantage to doing this, which is that `git blame` gets a bit trickier. However, following a coding style and using an automatic formatter has many advantages:

- no more mixed spaces and tabs in source files
- collaboration between multiple developers is easier as we all follow the same convention
- no-one has to remember a 20-page style guide. Instead, one only has to run `clang-format --style=Google -i path/to/file.js`. Clang-format is easily available these days, e.g., via Homebrew.

I think that in general, clang-format does a really good job. Consider the following:

```diff
-    OnlyKey.prototype.getLastMessage = function (type) {
-        return this.lastMessages[type] && this.lastMessages[type][0] && this.lastMessages[type][0].hasOwnProperty('text') ? this.lastMessages[type][0].text : '';
+  OnlyKey.prototype.getLastMessage = function(type) {
+    return this.lastMessages[type] && this.lastMessages[type][0] &&
+            this.lastMessages[type][0].hasOwnProperty('text') ?
+        this.lastMessages[type][0].text :
+        '';
 
   };
```

What do you think?